### PR TITLE
Extended Image Builder role policy

### DIFF
--- a/modernisation-platform/iam.tf
+++ b/modernisation-platform/iam.tf
@@ -80,6 +80,37 @@ resource "aws_iam_role" "image_builder_role" {
       }
     )
   }
+    inline_policy {
+    name = "ImageBuilderSessionManagerDocsPrereqs"
+    policy = jsonencode(
+      {
+        Statement = [
+          {
+            Action = [
+              "ssm:ListDocuments",
+              "ssm:ListDocumentVersions",
+              "ssm:DescribeInstanceInformation",
+              "ssm:DescribeDocumentParameters",
+              "ssm:DescribeInstanceProperties",
+              "ssm:CancelCommand",
+              "ssm:ListCommands",
+              "ssm:ListCommandInvocations",
+              "ec2:DescribeInstanceStatus",
+              "ssm:StartAutomationExecution",
+              "ssm:DescribeAutomationExecutions",
+
+
+            ]
+            Effect = "Allow"
+            Resource = [
+              "*",
+            ]
+          },
+        ]
+        Version = "2012-10-17"
+      }
+    )
+  }
 
   tags     = {}
   tags_all = {}

--- a/modernisation-platform/iam.tf
+++ b/modernisation-platform/iam.tf
@@ -80,7 +80,7 @@ resource "aws_iam_role" "image_builder_role" {
       }
     )
   }
-    inline_policy {
+  inline_policy {
     name = "ImageBuilderSessionManagerDocsPrereqs"
     policy = jsonencode(
       {


### PR DESCRIPTION
Additional permissions to allow invoking SSM documents from within the building AMIs, including retrieving SSM document information and information about the running instance. 

Currently the permission scope is *, however, it can be reduced later to specific documents. 