### PR TITLE
weblogic builds use shared key

### DIFF
--- a/teams/nomis/weblogic_pipeline_vars.tf
+++ b/teams/nomis/weblogic_pipeline_vars.tf
@@ -18,7 +18,7 @@ locals {
           volume_type           = "gp3"
           volume_size           = 30
           encrypted             = true
-          kms_key_id            = data.aws_kms_key.ebs_encryption_cmk.arn
+          kms_key_id            = data.aws_kms_key.hmpps_ebs_encryption_cmk.arn
           delete_on_termination = true
         },
         {
@@ -26,7 +26,7 @@ locals {
           volume_type           = "gp3"
           volume_size           = 150
           encrypted             = true
-          kms_key_id            = data.aws_kms_key.ebs_encryption_cmk.arn
+          kms_key_id            = data.aws_kms_key.hmpps_ebs_encryption_cmk.arn
           delete_on_termination = true
         }
       ]

--- a/teams/nomis/weblogic_pipeline_vars.tf
+++ b/teams/nomis/weblogic_pipeline_vars.tf
@@ -1,5 +1,5 @@
 locals {
-  version = "1.1.4"
+  version = "1.1.5"
   weblogic_pipeline = {
 
     pipeline = {


### PR DESCRIPTION
use the business unit shared CMK alias/ebs-hmpps to encrypt the weblogic ami's using imagebuilder 

copies the settings for the jumpserver ami build which already does this

version also needs updating otherwise checks complain about this