### PR TITLE
Feature/dsos 1421 add tags to ami

### DIFF
--- a/teams/nomis/locals.tf
+++ b/teams/nomis/locals.tf
@@ -18,11 +18,13 @@ locals {
   is-preproduction = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction"
   is_live          = [substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "live" : "non-live"]
 
+  # these are all based on https://technical-guidance.service.justice.gov.uk/documentation/standards/documenting-infrastructure-owners.html#tags-you-should-use
   tags = {
-    business-unit = "Platforms"
-    application   = "Modernisation Platform: ${terraform.workspace}"
+    business-unit = "HMPPS"
+    application   = upper(local.team_name)
     is-production = local.is-production
-    owner         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
+    owner         = "DSO: digital-studio-operations-team@digital.justice.gov.uk"
+    source        = "https://github.com/ministryofjustice/modernisation-platform-ami-builds/tree/main/teams/nomis"
   }
 
   ami_share_accounts = [

--- a/teams/nomis/modules/component_tags/main.tf
+++ b/teams/nomis/modules/component_tags/main.tf
@@ -1,5 +1,5 @@
 locals {
-  config = yamldecode(file("./${path.root}/components/${var.component_filename}"))["parameters"]
+  config = yamldecode(file("./components/${replace("${var.component_filename}", ".yml", "")}/${var.component_filename}"))["parameters"]
   params = flatten([
     for d, value in local.config : [
       for v, item in value : {

--- a/teams/nomis/modules/component_tags/main.tf
+++ b/teams/nomis/modules/component_tags/main.tf
@@ -1,0 +1,14 @@
+locals {
+  config = yamldecode(file("./${path.root}/components/${var.component_filename}"))["parameters"]
+  params = flatten([
+    for d, value in local.config : [
+        for v, item in value : {
+           "${replace((replace(v, "Version", "${var.component_filename}-component-version")), ".yml", "")}" = item.default
+        }
+    ]
+  ])
+
+  map = { for a in local.params: 
+    keys(a)[0] => values(a)[0]
+  }
+}

--- a/teams/nomis/modules/component_tags/main.tf
+++ b/teams/nomis/modules/component_tags/main.tf
@@ -2,13 +2,13 @@ locals {
   config = yamldecode(file("./${path.root}/components/${var.component_filename}"))["parameters"]
   params = flatten([
     for d, value in local.config : [
-        for v, item in value : {
-           "${replace((replace(v, "Version", "${var.component_filename}-component-version")), ".yml", "")}" = item.default
-        }
+      for v, item in value : {
+        "${replace((replace(v, "Version", "${var.component_filename}-component-version")), ".yml", "")}" = item.default
+      }
     ]
   ])
 
-  map = { for a in local.params: 
+  map = { for a in local.params :
     keys(a)[0] => values(a)[0]
   }
 }

--- a/teams/nomis/modules/component_tags/outputs.tf
+++ b/teams/nomis/modules/component_tags/outputs.tf
@@ -1,0 +1,3 @@
+output "component_tags" {
+  value = local.map
+}

--- a/teams/nomis/modules/component_tags/variables.tf
+++ b/teams/nomis/modules/component_tags/variables.tf
@@ -1,4 +1,4 @@
 variable "component_filename" {
-    description = "The config file for the component"
-    type = string
+  description = "The config file for the component"
+  type        = string
 }

--- a/teams/nomis/modules/component_tags/variables.tf
+++ b/teams/nomis/modules/component_tags/variables.tf
@@ -1,0 +1,4 @@
+variable "component_filename" {
+    description = "The config file for the component"
+    type = string
+}

--- a/teams/nomis/weblogic_pipeline.tf
+++ b/teams/nomis/weblogic_pipeline.tf
@@ -80,9 +80,9 @@ resource "aws_imagebuilder_image_recipe" "weblogic" {
   version      = local.weblogic_pipeline.recipe.version
 
   tags = merge({
-    weblogic_component  = "1.1.4"
-    weblogic_pipeline   = "${local.version}" # set in the weblogic_pipeline_vars.tf
-    pipeline_name       = "${local.weblogic_pipeline.pipeline.name}" # set in the weblogic_pipeline_vars.tf
+    weblogic_component = "1.1.4"
+    weblogic_pipeline  = "${local.version}"                         # set in the weblogic_pipeline_vars.tf
+    pipeline_name      = "${local.weblogic_pipeline.pipeline.name}" # set in the weblogic_pipeline_vars.tf
   }, local.tags)
 
 }

--- a/teams/nomis/weblogic_pipeline.tf
+++ b/teams/nomis/weblogic_pipeline.tf
@@ -135,16 +135,16 @@ resource "aws_imagebuilder_distribution_configuration" "weblogic" {
         user_ids = local.ami_share_accounts
       }
 
-      # local.tag_name are pulled from weblogic_pipeline_vars.tf
+      # local.<tag_name> are pulled from weblogic_pipeline_vars.tf
       # local.tags are pulled from locals.tf
       # module.component_tags.component_tags are pulled from the components/<component_name>/<component_name>.yml config
       ami_tags = merge({
-        release-or-patch  = "${local.instance}"
-        distro            = "${local.os_version}"                      # distro name and version
-        middleware        = "${local.middleware}"                      # middleware on the ami
-        weblogic-server   = "${local.weblogic_server}"                 # version of the weblogic app being used in the pipeline
-        pipeline-name     = "${local.weblogic_pipeline.pipeline.name}" # name of the pipeline
-        weblogic-pipeline = "${local.version}"                         # version of the pipeline
+        release-or-patch          = "${local.release_or_patch}"                # IMPORTANT: use "Release" when the application NOMIS version changes, use "Patch" otherwise
+        os-version                = "${local.os_version}"                      # distro name and version
+        middleware                = "${local.middleware}"                      # middleware on the ami
+        weblogic-server-version   = "${local.weblogic_server_version}"         # version of the weblogic app being used in the pipeline
+        pipeline-name             = "${local.weblogic_pipeline.pipeline.name}" # name of the pipeline
+        weblogic-pipeline-version = "${local.version}"                         # version of the pipeline
       }, local.tags, module.component_tags.component_tags)
 
     }

--- a/teams/nomis/weblogic_pipeline.tf
+++ b/teams/nomis/weblogic_pipeline.tf
@@ -79,14 +79,7 @@ resource "aws_imagebuilder_image_recipe" "weblogic" {
   parent_image = data.aws_ami.latest-rhel-610.id
   version      = local.weblogic_pipeline.recipe.version
 
-  tags = merge({
-    weblogic_component = "1.1.4"
-    weblogic_pipeline  = "${local.version}"                         # set in the weblogic_pipeline_vars.tf
-    pipeline_name      = "${local.weblogic_pipeline.pipeline.name}" # set in the weblogic_pipeline_vars.tf
-  }, local.tags)
-
 }
-
 
 resource "aws_imagebuilder_infrastructure_configuration" "weblogic" {
   description                   = local.weblogic_pipeline.infra_config.description
@@ -120,6 +113,13 @@ resource "aws_imagebuilder_component" "weblogic_components" {
   }
 }
 
+# pulls the parameters from the component's yml config and sets them as key-value pairs to tag the ami with
+module "component_tags" {
+  source = "./modules/component_tags" 
+
+  component_filename = "${local.weblogic_pipeline.components[0]}"
+}
+
 resource "aws_imagebuilder_distribution_configuration" "weblogic" {
   name = local.weblogic_pipeline.distribution.name
 
@@ -141,5 +141,18 @@ resource "aws_imagebuilder_distribution_configuration" "weblogic" {
       account_id         = local.environment_management.account_ids["nomis-test"]
       launch_template_id = data.aws_launch_template.weblogic-launch-templates.id
     }
+
+    # local.tag_name are pulled from weblogic_pipeline_vars.tf
+    # local.tags are pulled from locals.tf
+    # module.component_tags.component_tags are pulled from the components/<component_name>/<component_name>.yml config
+    ami_tags = merge({
+      release-or-patch   = "${local.instance}"
+      distro             = "${local.os_version}"                      # distro name and version
+      middleware         = "${local.middleware}"                      # middleware on the ami
+      weblogic-server    = "${local.weblogic_server}"                 # version of the weblogic app being used in the pipeline
+      pipeline-name      = "${local.weblogic_pipeline.pipeline.name}" # name of the pipeline
+      weblogic-pipeline  = "${local.version}"                         # version of the pipeline
+    }, local.tags, module.component_tags.component_tags)
+
   }
 }

--- a/teams/nomis/weblogic_pipeline.tf
+++ b/teams/nomis/weblogic_pipeline.tf
@@ -115,9 +115,9 @@ resource "aws_imagebuilder_component" "weblogic_components" {
 
 # pulls the parameters from the component's yml config and sets them as key-value pairs to tag the ami with
 module "component_tags" {
-  source = "./modules/component_tags" 
+  source = "./modules/component_tags"
 
-  component_filename = "${local.weblogic_pipeline.components[0]}"
+  component_filename = local.weblogic_pipeline.components[0]
 }
 
 resource "aws_imagebuilder_distribution_configuration" "weblogic" {
@@ -146,12 +146,12 @@ resource "aws_imagebuilder_distribution_configuration" "weblogic" {
     # local.tags are pulled from locals.tf
     # module.component_tags.component_tags are pulled from the components/<component_name>/<component_name>.yml config
     ami_tags = merge({
-      release-or-patch   = "${local.instance}"
-      distro             = "${local.os_version}"                      # distro name and version
-      middleware         = "${local.middleware}"                      # middleware on the ami
-      weblogic-server    = "${local.weblogic_server}"                 # version of the weblogic app being used in the pipeline
-      pipeline-name      = "${local.weblogic_pipeline.pipeline.name}" # name of the pipeline
-      weblogic-pipeline  = "${local.version}"                         # version of the pipeline
+      release-or-patch  = "${local.instance}"
+      distro            = "${local.os_version}"                      # distro name and version
+      middleware        = "${local.middleware}"                      # middleware on the ami
+      weblogic-server   = "${local.weblogic_server}"                 # version of the weblogic app being used in the pipeline
+      pipeline-name     = "${local.weblogic_pipeline.pipeline.name}" # name of the pipeline
+      weblogic-pipeline = "${local.version}"                         # version of the pipeline
     }, local.tags, module.component_tags.component_tags)
 
   }

--- a/teams/nomis/weblogic_pipeline.tf
+++ b/teams/nomis/weblogic_pipeline.tf
@@ -71,7 +71,6 @@ resource "aws_imagebuilder_image_recipe" "weblogic" {
     }
   }
 
-
   lifecycle {
     create_before_destroy = true
   }
@@ -79,6 +78,12 @@ resource "aws_imagebuilder_image_recipe" "weblogic" {
   name         = local.weblogic_pipeline.recipe.name
   parent_image = data.aws_ami.latest-rhel-610.id
   version      = local.weblogic_pipeline.recipe.version
+
+  tags = merge({
+    weblogic_component="1.1.4"
+    weblogic_pipeline="1.1.5"
+  }, local.tags)
+
 }
 
 

--- a/teams/nomis/weblogic_pipeline.tf
+++ b/teams/nomis/weblogic_pipeline.tf
@@ -80,8 +80,9 @@ resource "aws_imagebuilder_image_recipe" "weblogic" {
   version      = local.weblogic_pipeline.recipe.version
 
   tags = merge({
-    weblogic_component="1.1.4"
-    weblogic_pipeline="1.1.5"
+    weblogic_component  = "1.1.4"
+    weblogic_pipeline   = "${local.version}" # set in the weblogic_pipeline_vars.tf
+    pipeline_name       = "${local.weblogic_pipeline.pipeline.name}" # set in the weblogic_pipeline_vars.tf
   }, local.tags)
 
 }

--- a/teams/nomis/weblogic_pipeline.tf
+++ b/teams/nomis/weblogic_pipeline.tf
@@ -134,6 +134,19 @@ resource "aws_imagebuilder_distribution_configuration" "weblogic" {
       launch_permission {
         user_ids = local.ami_share_accounts
       }
+
+      # local.tag_name are pulled from weblogic_pipeline_vars.tf
+      # local.tags are pulled from locals.tf
+      # module.component_tags.component_tags are pulled from the components/<component_name>/<component_name>.yml config
+      ami_tags = merge({
+        release-or-patch  = "${local.instance}"
+        distro            = "${local.os_version}"                      # distro name and version
+        middleware        = "${local.middleware}"                      # middleware on the ami
+        weblogic-server   = "${local.weblogic_server}"                 # version of the weblogic app being used in the pipeline
+        pipeline-name     = "${local.weblogic_pipeline.pipeline.name}" # name of the pipeline
+        weblogic-pipeline = "${local.version}"                         # version of the pipeline
+      }, local.tags, module.component_tags.component_tags)
+
     }
 
     launch_template_configuration {
@@ -141,18 +154,5 @@ resource "aws_imagebuilder_distribution_configuration" "weblogic" {
       account_id         = local.environment_management.account_ids["nomis-test"]
       launch_template_id = data.aws_launch_template.weblogic-launch-templates.id
     }
-
-    # local.tag_name are pulled from weblogic_pipeline_vars.tf
-    # local.tags are pulled from locals.tf
-    # module.component_tags.component_tags are pulled from the components/<component_name>/<component_name>.yml config
-    ami_tags = merge({
-      release-or-patch  = "${local.instance}"
-      distro            = "${local.os_version}"                      # distro name and version
-      middleware        = "${local.middleware}"                      # middleware on the ami
-      weblogic-server   = "${local.weblogic_server}"                 # version of the weblogic app being used in the pipeline
-      pipeline-name     = "${local.weblogic_pipeline.pipeline.name}" # name of the pipeline
-      weblogic-pipeline = "${local.version}"                         # version of the pipeline
-    }, local.tags, module.component_tags.component_tags)
-
   }
 }

--- a/teams/nomis/weblogic_pipeline_vars.tf
+++ b/teams/nomis/weblogic_pipeline_vars.tf
@@ -51,7 +51,7 @@ locals {
     distribution = {
       name     = join("", [local.team_name, "_weblogic_", replace(local.version, ".", "_")])
       region   = "eu-west-2"
-      ami_name = join("_", [local.os_version, local.middleware, local.weblogic_server, local.instance, "{{ imagebuilder:buildDate }}"])
+      ami_name = join("_", [replace(local.os_version, ".", "-"), local.middleware, replace(local.weblogic_server, ".", "-"), local.instance, "{{ imagebuilder:buildDate }}" ])
     }
 
     components = [

--- a/teams/nomis/weblogic_pipeline_vars.tf
+++ b/teams/nomis/weblogic_pipeline_vars.tf
@@ -1,11 +1,11 @@
 locals {
-  version = "1.1.6" # change this value every time you update this file or the weblogic_pipeline.tf file 
+  version = "1.1.7" # change this value every time you update this file or the weblogic_pipeline.tf file 
 
   # Ideally these values should be pulled from the weblogic component file or the ansible when it is changed in DSOS-1446
-  os_version      = "RHEL6.10"
-  middleware      = "WebLogicAppServer"
-  weblogic_server = "10.3"
-  instance        = "Patch" # IMPORTANT: use "Release" when the application NOMIS version changes, use "Patch" otherwise
+  os_version              = "RHEL6.10"
+  middleware              = "WebLogicAppServer"
+  weblogic_server_version = "10.3"
+  release_or_patch        = "Patch" # IMPORTANT: use "Release" when the application NOMIS version changes, use "Patch" otherwise
 
   weblogic_pipeline = {
 
@@ -51,7 +51,7 @@ locals {
     distribution = {
       name     = join("", [local.team_name, "_weblogic_", replace(local.version, ".", "_")])
       region   = "eu-west-2"
-      ami_name = join("_", [replace(local.os_version, ".", "-"), local.middleware, replace(local.weblogic_server, ".", "-"), local.instance, "{{ imagebuilder:buildDate }}" ])
+      ami_name = join("_", [replace(local.os_version, ".", "-"), local.middleware, replace(local.weblogic_server_version, ".", "-"), local.release_or_patch, "{{ imagebuilder:buildDate }}" ])
     }
 
     components = [

--- a/teams/nomis/weblogic_pipeline_vars.tf
+++ b/teams/nomis/weblogic_pipeline_vars.tf
@@ -1,5 +1,5 @@
 locals {
-  version = "1.1.5"
+  version = "1.1.6"
   weblogic_pipeline = {
 
     pipeline = {

--- a/teams/nomis/weblogic_pipeline_vars.tf
+++ b/teams/nomis/weblogic_pipeline_vars.tf
@@ -1,6 +1,6 @@
 locals {
-  version         = "1.1.6" # change this value every time you update this file or the weblogic_pipeline.tf file 
-  
+  version = "1.1.6" # change this value every time you update this file or the weblogic_pipeline.tf file 
+
   # Ideally these values should be pulled from the weblogic component file or the ansible when it is changed in DSOS-1446
   os_version      = "RHEL6.10"
   middleware      = "WebLogicAppServer"

--- a/teams/nomis/weblogic_pipeline_vars.tf
+++ b/teams/nomis/weblogic_pipeline_vars.tf
@@ -51,7 +51,7 @@ locals {
     distribution = {
       name     = join("", [local.team_name, "_weblogic_", replace(local.version, ".", "_")])
       region   = "eu-west-2"
-      ami_name = join("_", [replace(local.os_version, ".", "-"), local.middleware, replace(local.weblogic_server_version, ".", "-"), local.release_or_patch, "{{ imagebuilder:buildDate }}" ])
+      ami_name = join("_", [replace(local.os_version, ".", "-"), local.middleware, replace(local.weblogic_server_version, ".", "-"), local.release_or_patch, "{{ imagebuilder:buildDate }}"])
     }
 
     components = [

--- a/teams/nomis/weblogic_pipeline_vars.tf
+++ b/teams/nomis/weblogic_pipeline_vars.tf
@@ -1,5 +1,12 @@
 locals {
-  version = "1.1.6"
+  version         = "1.1.6" # change this value every time you update this file or the weblogic_pipeline.tf file 
+  
+  # Ideally these values should be pulled from the weblogic component file or the ansible when it is changed in DSOS-1446
+  os_version      = "RHEL6.10"
+  middleware      = "WebLogicAppServer"
+  weblogic_server = "10.3"
+  instance        = "Patch" # IMPORTANT: use "Release" when the application NOMIS version changes, use "Patch" otherwise
+
   weblogic_pipeline = {
 
     pipeline = {
@@ -44,7 +51,7 @@ locals {
     distribution = {
       name     = join("", [local.team_name, "_weblogic_", replace(local.version, ".", "_")])
       region   = "eu-west-2"
-      ami_name = join("", [local.team_name, "_Weblogic_{{ imagebuilder:buildDate }}"])
+      ami_name = join("_", [local.os_version, local.middleware, local.weblogic_server, local.instance, "{{ imagebuilder:buildDate }}"])
     }
 
     components = [


### PR DESCRIPTION
weblogic ami now conforms to ami naming/tagging strategy
added a module that pulls the component version for the ami out of the relevant components/<component_name>.yml file
this can be re-used when it comes to applying these tag values to the other components