### PR TITLE
Adding Nomis team as codeowners for their team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @ministryofjustice/modernisation-platform
+/teams/nomis @ministryofjustice/studio-webops
+/ansible @ministryofjustice/studio-webops


### PR DESCRIPTION
The Nomis team know what they are doing, MP aren't adding any value by reviewing this as well.