### PR TITLE
Feeding windows exporter version to the component document.

### DIFF
--- a/teams/nomis/pipelines/jumpserver/components/jumpserver/jumpserver.yml
+++ b/teams/nomis/pipelines/jumpserver/components/jumpserver/jumpserver.yml
@@ -6,7 +6,7 @@ parameters:
   - Version:
       type: string
       default: "1.0.4"
-      description: Component version (update this each time the file changes)
+      description: Component version, set outside of this document. Update this in the pipeline variables, each time the file changes.
   - Platform:
       type: string
       default: "Windows"

--- a/teams/nomis/pipelines/jumpserver/components/jumpserver/prometheus_windows_exporter.yml
+++ b/teams/nomis/pipelines/jumpserver/components/jumpserver/prometheus_windows_exporter.yml
@@ -12,9 +12,9 @@ parameters:
       default: "Windows"
       description: Platform.
   - WindowsExporterVersion:
-    type: string
-    default: "0.18.0"
-    description: Version of the prometheus-windows-exporter.
+      type: string
+      default: "0.18.0"
+      description: Version of the prometheus-windows-exporter.
 phases:
   - name: build
     steps:

--- a/teams/nomis/pipelines/jumpserver/components/jumpserver/prometheus_windows_exporter.yml
+++ b/teams/nomis/pipelines/jumpserver/components/jumpserver/prometheus_windows_exporter.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: "1.0.1"
+      default: "1.0.2"
       description: Component version (update this each time the file changes).
   - Platform:
       type: string
@@ -13,8 +13,7 @@ parameters:
       description: Platform.
   - WindowsExporterVersion:
       type: string
-      default: "0.18.0"
-      description: Version of the prometheus-windows-exporter.
+      description: Version of the prometheus-windows-exporter, set outside of this document.
 phases:
   - name: build
     steps:

--- a/teams/nomis/pipelines/jumpserver/components/jumpserver/prometheus_windows_exporter.yml
+++ b/teams/nomis/pipelines/jumpserver/components/jumpserver/prometheus_windows_exporter.yml
@@ -13,7 +13,7 @@ parameters:
       description: Platform.
   - WindowsExporterVersion:
     type: string
-    default: "0.19.0"
+    default: "0.18.0"
     description: Version of the prometheus-windows-exporter.
 phases:
   - name: build
@@ -22,4 +22,4 @@ phases:
         action: ExecutePowerShell
         inputs:
           commands:
-            - choco install -y prometheus-windows-exporter.install --version {{ WindowsExporterVersion }} --params '"/ListenPort:9100"'
+            - choco install -y prometheus-windows-exporter.install --version '{{ WindowsExporterVersion }}' --params '"/ListenPort:9100"'

--- a/teams/nomis/pipelines/jumpserver/components/jumpserver/prometheus_windows_exporter.yml
+++ b/teams/nomis/pipelines/jumpserver/components/jumpserver/prometheus_windows_exporter.yml
@@ -6,14 +6,14 @@ parameters:
   - Version:
       type: string
       default: "1.0.2"
-      description: Component version (update this each time the file changes).
+      description: Component version, set outside of this document. Update this in the pipeline variables, each time the file changes.
   - Platform:
       type: string
       default: "Windows"
       description: Platform.
   - WindowsExporterVersion:
       type: string
-      description: Version of the prometheus-windows-exporter, set outside of this document.
+      description: Version of the prometheus-windows-exporter, set outside of this document (in the pipeline variables).
 phases:
   - name: build
     steps:

--- a/teams/nomis/pipelines/jumpserver/components/jumpserver/prometheus_windows_exporter.yml
+++ b/teams/nomis/pipelines/jumpserver/components/jumpserver/prometheus_windows_exporter.yml
@@ -5,12 +5,16 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: "1.0.0"
+      default: "1.0.1"
       description: Component version (update this each time the file changes).
   - Platform:
       type: string
       default: "Windows"
       description: Platform.
+  - WindowsExporterVersion:
+    type: string
+    default: "0.19.0"
+    description: Version of the prometheus-windows-exporter.
 phases:
   - name: build
     steps:
@@ -18,4 +22,4 @@ phases:
         action: ExecutePowerShell
         inputs:
           commands:
-            - choco install -y prometheus-windows-exporter.install --version 0.19.0 --params '"/ListenPort:9100"'
+            - choco install -y prometheus-windows-exporter.install --version {{ WindowsExporterVersion }} --params '"/ListenPort:9100"'

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -91,7 +91,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "jumpserver" {
 // create each component in team directory
 resource "aws_imagebuilder_component" "jumpserver_components" {
   //for_each = { for file in local.jumpserver_pipeline.components : file => yamldecode(file("components/jumpserver/${file}")) }
-  for_each = toset([for comp in local.jumpserver_pipeline.components : yamldecode(file("components/jumpserver/${comp.content}"))])
+  for_each = { for comp in local.jumpserver_pipeline.components : comp.content => yamldecode(file("components/jumpserver/${comp.content}")) }
 
   data     = file("components/jumpserver/${each.key}")
   name     = join("_", ["nomis", trimsuffix(each.key, ".yml")])

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -49,7 +49,7 @@ resource "aws_imagebuilder_image_recipe" "jumpserver" {
     content {
       component_arn = aws_imagebuilder_component.jumpserver_components[component.key].arn
       dynamic "parameter"{
-        for_each = local.jumpserver_pipeline.components.parameters
+        for_each = component.value.parameters
         content {
           parameter {
             name = parameter.value.name

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -48,6 +48,15 @@ resource "aws_imagebuilder_image_recipe" "jumpserver" {
     for_each = toset(local.jumpserver_pipeline.components)
     content {
       component_arn = aws_imagebuilder_component.jumpserver_components[component.key].arn
+      dynamic "parameter"{
+        for_each = toset(local.jumpserver_pipeline.components.parameters)
+        content {
+          parameter {
+            name = parameter.value.name
+            value = parameter.value.value
+          }
+        }
+      }
     }
   }
 
@@ -81,7 +90,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "jumpserver" {
 
 // create each component in team directory
 resource "aws_imagebuilder_component" "jumpserver_components" {
-  for_each = { for file in local.jumpserver_pipeline.components : file => yamldecode(file("components/jumpserver/${file}")) }
+  for_each = { for file in local.jumpserver_pipeline.components : file => yamldecode(file("components/jumpserver/${file.content}")) }
 
   data     = file("components/jumpserver/${each.key}")
   name     = join("_", ["nomis", trimsuffix(each.key, ".yml")])

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -49,7 +49,7 @@ resource "aws_imagebuilder_image_recipe" "jumpserver" {
     content {
       component_arn = aws_imagebuilder_component.jumpserver_components[component.value.content].arn
       dynamic "parameter" {
-        for_each = { for param in component.value.parameters : param => param if param != {} }
+        for_each = tomap({ for param in component.value.parameters : param => param if param != {} })
         content {
           name  = parameter.key
           value = parameter.value

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -47,7 +47,7 @@ resource "aws_imagebuilder_image_recipe" "jumpserver" {
   dynamic "component" {
     for_each = local.jumpserver_pipeline.components
     content {
-      component_arn = aws_imagebuilder_component.jumpserver_components[component.key].arn
+      component_arn = aws_imagebuilder_component.jumpserver_components[component.value.content].arn
       dynamic "parameter" {
         for_each = [for param in component.value.parameters : param if param != {}]
         content {

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -49,7 +49,7 @@ resource "aws_imagebuilder_image_recipe" "jumpserver" {
     content {
       component_arn = aws_imagebuilder_component.jumpserver_components[component.key].arn
       dynamic "parameter"{
-        for_each = [for param in component.value.parameters : param if param != {}]
+        for_each = [for param in component.value.parameters : param if param != null]
         content {
           parameter {
             name = parameter.key

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -49,7 +49,7 @@ resource "aws_imagebuilder_image_recipe" "jumpserver" {
     content {
       component_arn = aws_imagebuilder_component.jumpserver_components[component.key].arn
       dynamic "parameter"{
-        for_each = toset(local.jumpserver_pipeline.components.parameters)
+        for_each = local.jumpserver_pipeline.components.parameters
         content {
           parameter {
             name = parameter.value.name

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -45,7 +45,7 @@ resource "aws_imagebuilder_image_recipe" "jumpserver" {
     }
   }
   dynamic "component" {
-    for_each = toset(local.jumpserver_pipeline.components)
+    for_each = local.jumpserver_pipeline.components
     content {
       component_arn = aws_imagebuilder_component.jumpserver_components[component.key].arn
       dynamic "parameter"{

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -49,7 +49,7 @@ resource "aws_imagebuilder_image_recipe" "jumpserver" {
     content {
       component_arn = aws_imagebuilder_component.jumpserver_components[component.value.content].arn
       dynamic "parameter" {
-        for_each = [for param in component.value.parameters : param if param != {}]
+        for_each = { for param in component.value.parameters : param => param if param != {} }
         content {
           name  = parameter.key
           value = parameter.value

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -49,7 +49,7 @@ resource "aws_imagebuilder_image_recipe" "jumpserver" {
     content {
       component_arn = aws_imagebuilder_component.jumpserver_components[component.key].arn
       dynamic "parameter"{
-        for_each = [for param in component.value.parameters : param if param != {}]
+        for_each = [for param in component.value.parameters : param if length(param) != 0]
         content {
           parameter {
             name = parameter.key

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -90,7 +90,8 @@ resource "aws_imagebuilder_infrastructure_configuration" "jumpserver" {
 
 // create each component in team directory
 resource "aws_imagebuilder_component" "jumpserver_components" {
-  for_each = { for file in local.jumpserver_pipeline.components : file => yamldecode(file("components/jumpserver/${file.content}")) }
+  //for_each = { for file in local.jumpserver_pipeline.components : file => yamldecode(file("components/jumpserver/${file}")) }
+  for_each = toset([for comp in local.jumpserver_pipeline.components : yamldecode(file("components/jumpserver/${comp.content}"))])
 
   data     = file("components/jumpserver/${each.key}")
   name     = join("_", ["nomis", trimsuffix(each.key, ".yml")])

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -48,13 +48,11 @@ resource "aws_imagebuilder_image_recipe" "jumpserver" {
     for_each = local.jumpserver_pipeline.components
     content {
       component_arn = aws_imagebuilder_component.jumpserver_components[component.key].arn
-      dynamic "parameter"{
-        for_each = [for param in component.value.parameters : param if length(param) != 0]
+      dynamic "parameter" {
+        for_each = [for param in component.value.parameters : param if param != {}]
         content {
-          parameter {
-            name = parameter.key
-            value = parameter.value
-          }
+          name  = parameter.key
+          value = parameter.value
         }
       }
     }

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -49,7 +49,7 @@ resource "aws_imagebuilder_image_recipe" "jumpserver" {
     content {
       component_arn = aws_imagebuilder_component.jumpserver_components[component.key].arn
       dynamic "parameter"{
-        for_each = component.value.parameters
+        for_each = [for param in component.value.parameters : param if param != {}]
         content {
           parameter {
             name = parameter.key

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -49,7 +49,7 @@ resource "aws_imagebuilder_image_recipe" "jumpserver" {
     content {
       component_arn = aws_imagebuilder_component.jumpserver_components[component.value.content].arn
       dynamic "parameter" {
-        for_each = tomap({ for param in component.value.parameters : param => param if param != {} })
+        for_each = { for param_key, param_value in component.value.parameters : param_key => param_value if component.value.parameters != {} }
         content {
           name  = parameter.key
           value = parameter.value

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -49,7 +49,7 @@ resource "aws_imagebuilder_image_recipe" "jumpserver" {
     content {
       component_arn = aws_imagebuilder_component.jumpserver_components[component.key].arn
       dynamic "parameter"{
-        for_each = [for param in component.value.parameters : param if param != null]
+        for_each = [for param in component.value.parameters : param if param != {}]
         content {
           parameter {
             name = parameter.key

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -89,12 +89,12 @@ resource "aws_imagebuilder_infrastructure_configuration" "jumpserver" {
 // create each component in team directory
 resource "aws_imagebuilder_component" "jumpserver_components" {
   //for_each = { for file in local.jumpserver_pipeline.components : file => yamldecode(file("components/jumpserver/${file}")) }
-  for_each = { for comp in local.jumpserver_pipeline.components : comp.content => yamldecode(file("components/jumpserver/${comp.content}")) }
+  for_each = { for component in local.jumpserver_pipeline.components : component.content => component.parameters }
 
   data     = file("components/jumpserver/${each.key}")
   name     = join("_", ["nomis", trimsuffix(each.key, ".yml")])
   platform = yamldecode(file("components/jumpserver/${each.key}")).parameters[1].Platform.default
-  version  = yamldecode(file("components/jumpserver/${each.key}")).parameters[0].Version.default
+  version  = each.value.Version
 
   lifecycle {
     create_before_destroy = true

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline.tf
@@ -52,8 +52,8 @@ resource "aws_imagebuilder_image_recipe" "jumpserver" {
         for_each = component.value.parameters
         content {
           parameter {
-            name = parameter.value.name
-            value = parameter.value.value
+            name = parameter.key
+            value = parameter.value
           }
         }
       }

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
@@ -45,11 +45,11 @@ locals {
           name = "WindowsExporterVersion",
           value = "0.19.0"
         }
-      },
-      {
-        content = "jumpserver.yml",
-        parameters = {}
       }
+//      {
+//        content = "jumpserver.yml",
+//        parameters = {}
+//      }
     ]
 
     aws_components = [

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
@@ -1,4 +1,14 @@
 locals {
+  # Recipe's version:
+  jumpserver_recipe_version = "1.1.1"
+
+  # Component's version:
+  prometheus_windows_exporter_component_version = "1.0.3"
+  jumpserver_component_version = "1.0.5"
+
+  # Software's version:
+  prometheus_windows_exporter_version = "0.19.0"
+
   jumpserver_pipeline = {
     pipeline = {
       name     = join("", [local.team_name, "_jumpserver"])
@@ -8,7 +18,7 @@ locals {
     recipe = {
       name         = join("", [local.team_name, "_jumpserver"])
       parent_image = "arn:aws:imagebuilder:eu-west-2:${data.aws_caller_identity.current.account_id}:image/mp-windowsserver2022/x.x.x"
-      version      = "1.1.0"
+      version      = local.jumpserver_recipe_version
       device_name  = "/dev/sda1"
 
       ebs_block_device = [
@@ -42,12 +52,15 @@ locals {
       {
         content = "prometheus_windows_exporter.yml",
         parameters = {
-          WindowsExporterVersion = "0.19.0"
+          WindowsExporterVersion = local.prometheus_windows_exporter_version,
+          Version = local.prometheus_windows_exporter_component_version
         }
       },
       {
         content    = "jumpserver.yml",
-        parameters = {}
+        parameters = {
+          Version = local.jumpserver_component_version
+        }
       }
     ]
 

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
@@ -46,7 +46,8 @@ locals {
         }
       },
       {
-        content = "jumpserver.yml"
+        content = "jumpserver.yml",
+        parameters = {}
       }
     ]
 

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
@@ -45,11 +45,11 @@ locals {
           name = "WindowsExporterVersion",
           value = "0.19.0"
         }
+      },
+      {
+        content = "jumpserver.yml",
+        parameters = {}
       }
-//      {
-//        content = "jumpserver.yml",
-//        parameters = {}
-//      }
     ]
 
     aws_components = [

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
@@ -4,7 +4,7 @@ locals {
 
   # Component's version:
   prometheus_windows_exporter_component_version = "1.0.3"
-  jumpserver_component_version = "1.0.5"
+  jumpserver_component_version                  = "1.0.5"
 
   # Software's version:
   prometheus_windows_exporter_version = "0.19.0"
@@ -53,11 +53,11 @@ locals {
         content = "prometheus_windows_exporter.yml",
         parameters = {
           WindowsExporterVersion = local.prometheus_windows_exporter_version,
-          Version = local.prometheus_windows_exporter_component_version
+          Version                = local.prometheus_windows_exporter_component_version
         }
       },
       {
-        content    = "jumpserver.yml",
+        content = "jumpserver.yml",
         parameters = {
           Version = local.jumpserver_component_version
         }

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
@@ -47,8 +47,7 @@ locals {
         }
       },
       {
-        content = "jumpserver.yml",
-        parameters = {}
+        content = "jumpserver.yml"
       }
     ]
 

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
@@ -47,7 +47,7 @@ locals {
       },
       {
         content = "jumpserver.yml",
-        parameters = {}
+        parameters = null
       }
     ]
 

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
@@ -46,7 +46,7 @@ locals {
         }
       },
       {
-        content = "jumpserver.yml",
+        content    = "jumpserver.yml",
         parameters = {}
       }
     ]

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
@@ -42,8 +42,7 @@ locals {
       {
         content = "prometheus_windows_exporter.yml",
         parameters = {
-          name = "WindowsExporterVersion",
-          value = "0.19.0"
+          WindowsExporterVersion = "0.19.0"
         }
       },
       {

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
@@ -47,7 +47,7 @@ locals {
       },
       {
         content = "jumpserver.yml",
-        parameters = null
+        parameters = {}
       }
     ]
 

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
@@ -8,7 +8,7 @@ locals {
     recipe = {
       name         = join("", [local.team_name, "_jumpserver"])
       parent_image = "arn:aws:imagebuilder:eu-west-2:${data.aws_caller_identity.current.account_id}:image/mp-windowsserver2022/x.x.x"
-      version      = "1.0.10"
+      version      = "1.1.0"
       device_name  = "/dev/sda1"
 
       ebs_block_device = [
@@ -28,7 +28,7 @@ locals {
       instance_types     = ["t3.medium"]
       name               = join("", [local.team_name, "_jumpserver"])
       security_group_ids = [data.terraform_remote_state.modernisation-platform-repo.outputs.image_builder_security_group_id]
-      subnet_id          = "${data.terraform_remote_state.modernisation-platform-repo.outputs.non_live_private_subnet_ids[0]}"
+      subnet_id          = data.terraform_remote_state.modernisation-platform-repo.outputs.non_live_private_subnet_ids[0]
       terminate_on_fail  = true
     }
 
@@ -39,8 +39,17 @@ locals {
     }
 
     components = [
-      "prometheus_windows_exporter.yml",
-      "jumpserver.yml"
+      {
+        content = "prometheus_windows_exporter.yml",
+        parameters = {
+          name = "WindowsExporterVersion",
+          value = "0.19.0"
+        }
+      },
+      {
+        content = "jumpserver.yml",
+        parameters = {}
+      }
     ]
 
     aws_components = [

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
@@ -1,10 +1,10 @@
 locals {
   # Recipe's version:
-  jumpserver_recipe_version = "1.1.1"
+  jumpserver_recipe_version = "1.1.2"
 
   # Component's version:
-  prometheus_windows_exporter_component_version = "1.0.3"
-  jumpserver_component_version                  = "1.0.5"
+  prometheus_windows_exporter_component_version = "1.0.4"
+  jumpserver_component_version                  = "1.0.6"
 
   # Software's version:
   prometheus_windows_exporter_version = "0.19.0"


### PR DESCRIPTION
Version of windows exporter and component versions are now passed as a variable in the jumpserver recipe.

The AMI was created with the latest recipe and tested in a test jumpserver (the right version of windows exporter is installed and the jumpserver is picked up by prometheus).