### PR TITLE
Removing default component version value from the components

### DIFF
--- a/teams/nomis/pipelines/jumpserver/components/jumpserver/jumpserver.yml
+++ b/teams/nomis/pipelines/jumpserver/components/jumpserver/jumpserver.yml
@@ -5,7 +5,6 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: "1.0.4"
       description: Component version, set outside of this document. Update this in the pipeline variables, each time the file changes.
   - Platform:
       type: string

--- a/teams/nomis/pipelines/jumpserver/components/jumpserver/prometheus_windows_exporter.yml
+++ b/teams/nomis/pipelines/jumpserver/components/jumpserver/prometheus_windows_exporter.yml
@@ -5,7 +5,6 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: "1.0.2"
       description: Component version, set outside of this document. Update this in the pipeline variables, each time the file changes.
   - Platform:
       type: string

--- a/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
+++ b/teams/nomis/pipelines/jumpserver/jumpserver_pipeline_vars.tf
@@ -1,10 +1,10 @@
 locals {
   # Recipe's version:
-  jumpserver_recipe_version = "1.1.2"
+  jumpserver_recipe_version = "1.1.3"
 
   # Component's version:
-  prometheus_windows_exporter_component_version = "1.0.4"
-  jumpserver_component_version                  = "1.0.6"
+  prometheus_windows_exporter_component_version = "1.0.5"
+  jumpserver_component_version                  = "1.0.7"
 
   # Software's version:
   prometheus_windows_exporter_version = "0.19.0"


### PR DESCRIPTION
Component version of jumpserver and prometheus-windows-exporter is now being set in the pipeline local variables, hence removing them from the component documents to avoid confusion.