### PR TITLE
6 10 base image to development

### DIFF
--- a/teams/nomis/modules/imagebuilder/main.tf
+++ b/teams/nomis/modules/imagebuilder/main.tf
@@ -105,7 +105,9 @@ resource "aws_imagebuilder_image_pipeline" "this" {
   infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.this.arn
   distribution_configuration_arn   = aws_imagebuilder_distribution_configuration.this.arn
   tags                             = local.tags
-
+  image_tests_configuration {
+    image_tests_enabled = false
+  }
   schedule {
     schedule_expression = var.image_pipeline.schedule.schedule_expression
   }

--- a/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
@@ -58,9 +58,11 @@ distribution_target_account_names_by_branch = {
   main = [
     "core-shared-services-production",
     "nomis-test"
+    "nomis-development"
   ]
   default = [
     "core-shared-services-production",
     "nomis-test"
+    "nomis-development"
   ]
 }

--- a/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_6_10_baseimage = {
-    configuration_version = "0.1.5"
+    configuration_version = "0.1.6"
     description           = "nomis rhel 6.10 base image"
 
     tags = {
@@ -57,12 +57,12 @@ EOF
 distribution_target_account_names_by_branch = {
   main = [
     "core-shared-services-production",
-    "nomis-test"
+    "nomis-test",
     "nomis-development"
   ]
   default = [
     "core-shared-services-production",
-    "nomis-test"
+    "nomis-test",
     "nomis-development"
   ]
 }


### PR DESCRIPTION
update the 6.10 image distribution to include nomis test, also remove the image pipeline tests to save a bit of time on builds