### PR TITLE
Nomis DSOS-1478: fix rhel79 image

### DIFF
--- a/teams/nomis/README.md
+++ b/teams/nomis/README.md
@@ -8,7 +8,8 @@ Each image has it's own terraform state.
 
 If you make a change to a module, or ansible, this won't automatically
 trigger a pipeline run. You must increment the version number in the
-relevant image directory to trigger the run.
+relevant image directory to trigger the run. Don't forget to update
+the component version when there is a change to the component as well.
 
 You can manually plan and apply terraform prior to raising a PR. This is
 not recommended if multiple people are working on the same image.
@@ -24,7 +25,56 @@ modules/    - the imagebuilder module
 components/ - custom components, e.g. install ansible
 imagedir1/  - example image directory
 imagedir2/  - example image directory
+main.tf     - common terraform symbolic linked by each image dir
 ```
 
 To run pipeline manually, you can either specify "all" to run terraform
 across all the images, or give a specific image directory, e.g. "imagedir1"
+
+## Distribution of Images
+
+The common terraform allows different distribution configs to be defined
+depending on the branch worked on. For example, if you are developing
+a new image in a branch, you can define this just to be distributed to a
+development environment. Once the code is merged into main, you can then
+distribute to other environments.
+
+This is controlled by the `distribution_configuration_by_branch` variable.
+This is a map where the key is the name of the branch, e.g. main, release.
+The `default` key is used if the plan is run locally, or the name of the
+branch isn't defined in the map.
+
+The value corresponds to the `distribution_configuration` defined in
+the imagebuilder module.
+
+## Making use of ASGs
+
+Building AMI images is slow. If you are building components or
+ansible code, it's quickest to test the set of commands or
+ansible code on a running EC2 instance. A convenient way of doing
+this is by using auto scale groups (ASG).
+
+In the relevant development environment, e.g. `nomis-development`,
+ensure there is an ASG group defined for each base image. In the
+`distribution_configuration` for the base image, ensure there is
+a `launch_template_configuration` corresponding to that ASG and
+the image `ami_distribution_configuration.target_account_ids_or_names`
+contains the development account name, e.g. `nomis-development`.
+
+When a new base image is built, it will be available to use by the ASG
+in the development environment. Refreshing the EC2 instance, e.g. by
+scaling down and up, will create a new EC2 instance using the new AMI
+
+# Developer Workflow
+
+Tips:
+
+- avoid multiple people working on the same image
+- pre-test ansible/scripts on the relevant parent image
+- create a branch, update version numbers, commit and push your changes
+- use/setup ASGs to help quickly test your changes in the development account
+- manually run the `nomis` pipeline. First plan, and then apply.
+- manually trigger a build of the image
+- test the image using the ASG
+- when fully tested, increment version number again and create a PR
+- once PR merged, manually run the pipeline. The image will then be available in the configured environments

--- a/teams/nomis/components/rhel_6_10_baseimage/rhel_6_10_baseimage.yml
+++ b/teams/nomis/components/rhel_6_10_baseimage/rhel_6_10_baseimage.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: "0.1.3"
+      default: "0.1.4"
       description: Component version (update this each time the file changes)
   - Platform:
       type: string

--- a/teams/nomis/components/rhel_6_10_weblogic_appserver_10_3/weblogic.yml
+++ b/teams/nomis/components/rhel_6_10_weblogic_appserver_10_3/weblogic.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: "1.1.6"
+      default: "1.1.7"
       description: Component version (update this each time the file changes)
   - Platform:
       type: string

--- a/teams/nomis/components/rhel_7_9_baseimage/rhel_7_9_baseimage.yml.tftpl
+++ b/teams/nomis/components/rhel_7_9_baseimage/rhel_7_9_baseimage.yml.tftpl
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: "1.1.4"
+      default: "1.1.5"
       description: Component version (update this each time the file changes)
   - Platform:
       type: string

--- a/teams/nomis/components/rhel_7_9_baseimage/rhel_7_9_baseimage.yml.tftpl
+++ b/teams/nomis/components/rhel_7_9_baseimage/rhel_7_9_baseimage.yml.tftpl
@@ -60,8 +60,8 @@ phases:
 
               # Download playbook
               mkdir /tmp/node-exporter-ansible-playbook && cd "$_"
-              echo "Cloning using branch=${BRANCH_NAME}"
-              git clone -b ${BRANCH_NAME} --single-branch "https://github.com/ministryofjustice/modernisation-platform-ami-builds.git"
+              echo "Cloning using branch=${branch}"
+              git clone -b ${branch} --single-branch "https://github.com/ministryofjustice/modernisation-platform-ami-builds.git"
               cd modernisation-platform-ami-builds/ansible
 
               # Install requirements in virtual env

--- a/teams/nomis/components/rhel_7_9_baseimage/rhel_7_9_baseimage.yml.tftpl
+++ b/teams/nomis/components/rhel_7_9_baseimage/rhel_7_9_baseimage.yml.tftpl
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: "1.1.5"
+      default: "1.1.6"
       description: Component version (update this each time the file changes)
   - Platform:
       type: string

--- a/teams/nomis/components/rhel_7_9_baseimage/rhel_7_9_baseimage.yml.tftpl
+++ b/teams/nomis/components/rhel_7_9_baseimage/rhel_7_9_baseimage.yml.tftpl
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: "1.1.3"
+      default: "1.1.4"
       description: Component version (update this each time the file changes)
   - Platform:
       type: string

--- a/teams/nomis/components/rhel_7_9_baseimage/rhel_7_9_baseimage.yml.tmpl
+++ b/teams/nomis/components/rhel_7_9_baseimage/rhel_7_9_baseimage.yml.tmpl
@@ -47,8 +47,6 @@ phases:
             - |
               set -e
               cd /tmp
-              echo ${BRANCH_NAME}
-              exit 0
 
               # install, create, activate virtual environment
               pip3.9 install virtualenv
@@ -62,6 +60,7 @@ phases:
 
               # Download playbook
               mkdir /tmp/node-exporter-ansible-playbook && cd "$_"
+              echo "Cloning using branch=${BRANCH_NAME}"
               git clone -b ${BRANCH_NAME} --single-branch "https://github.com/ministryofjustice/modernisation-platform-ami-builds.git"
               cd modernisation-platform-ami-builds/ansible
 
@@ -80,5 +79,5 @@ phases:
 
               # Deactivate virtual env and cleanup
               deactivate
-              rm -r /tmp/python-venv
-              rm -r /tmp/node-exporter-ansible-playbook
+              rm -rf /tmp/python-venv
+              rm -rf /tmp/node-exporter-ansible-playbook

--- a/teams/nomis/components/rhel_7_9_baseimage/rhel_7_9_baseimage.yml.tmpl
+++ b/teams/nomis/components/rhel_7_9_baseimage/rhel_7_9_baseimage.yml.tmpl
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: "1.1.2"
+      default: "1.1.3"
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -47,6 +47,8 @@ phases:
             - |
               set -e
               cd /tmp
+              echo ${BRANCH_NAME}
+              exit 0
 
               # install, create, activate virtual environment
               pip3.9 install virtualenv

--- a/teams/nomis/components/rhel_7_9_oracledb_11_2/database.yml.tftpl
+++ b/teams/nomis/components/rhel_7_9_oracledb_11_2/database.yml.tftpl
@@ -34,7 +34,8 @@ phases:
 
               # Download playbook
               mkdir /tmp/database-ansible-playbook && cd "$_"
-              git clone -b ${BRANCH_NAME} --single-branch "https://github.com/ministryofjustice/modernisation-platform-ami-builds.git"
+              echo "Cloning using branch=${branch}"
+              git clone -b ${branch} --single-branch "https://github.com/ministryofjustice/modernisation-platform-ami-builds.git"
               cd modernisation-platform-ami-builds/ansible
 
               # Install requirements in virtual env

--- a/teams/nomis/components/rhel_7_9_oracledb_11_2/database.yml.tftpl
+++ b/teams/nomis/components/rhel_7_9_oracledb_11_2/database.yml.tftpl
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: "1.0.8"
+      default: "1.0.9"
       description: Component version (update this each time the file changes)
   - Platform:
       type: string

--- a/teams/nomis/modules/imagebuilder/locals.tf
+++ b/teams/nomis/modules/imagebuilder/locals.tf
@@ -8,15 +8,15 @@ locals {
   }
 
   component_template_args = {
-    BRANCH_NAME = var.branch == "" ? "main" : var.branch
+    branch = var.branch == "" ? "main" : var.branch
   }
 
   components_custom_yaml = {
     for component_filename in var.image_recipe.components_custom :
     component_filename => yamldecode(
-      length(regexall(".*tmpl", component_filename)) > 0 ?
-      templatefile("${component_filename}.tftpl", local.component_template_args) :
-      file("${component_filename}.deliberateerror")
+      length(regexall(".*tftpl", component_filename)) > 0 ?
+      templatefile(component_filename", local.component_template_args) :
+      file(component_filename)
     )
   }
 

--- a/teams/nomis/modules/imagebuilder/locals.tf
+++ b/teams/nomis/modules/imagebuilder/locals.tf
@@ -8,15 +8,15 @@ locals {
   }
 
   component_template_args = {
-    BRANCH_NAME = var.branch
+    BRANCH_NAME = var.branch == "" ? "main" : var.branch
   }
 
   components_custom_yaml = {
     for component_filename in var.image_recipe.components_custom :
     component_filename => yamldecode(
       length(regexall(".*tmpl", component_filename)) > 0 ?
-      templatefile(component_filename, local.component_template_args) :
-      file(component_filename)
+      templatefile("${component_filename}.tftpl", local.component_template_args) :
+      file("${component_filename}.deliberateerror")
     )
   }
 

--- a/teams/nomis/modules/imagebuilder/locals.tf
+++ b/teams/nomis/modules/imagebuilder/locals.tf
@@ -11,18 +11,24 @@ locals {
     branch = var.branch == "" ? "main" : var.branch
   }
 
-  components_custom_yaml = {
+  components_custom_data = {
     for component_filename in var.image_recipe.components_custom :
-    component_filename => yamldecode(
-      length(regexall(".*tftpl", component_filename)) > 0 ?
-      templatefile(component_filename, local.component_template_args) :
-      file(component_filename)
-    )
+    component_filename => length(regexall(".*tftpl", component_filename)) > 0 ?
+    templatefile(component_filename, local.component_template_args) :
+    file(component_filename)
+  }
+
+  components_custom_yaml = {
+    for component_filename, data in local.components_custom_data :
+    component_filename => {
+      raw  = data
+      yaml = yamldecode(data)
+    }
   }
 
   components_custom_versions = {
-    for component_filename, component_yaml in local.components_custom_yaml :
-    "${component_yaml.name}-version" => component_yaml.parameters[0].Version.default
+    for component_filename, data in local.components_custom_yaml :
+    "${data.yaml.name}-version" => data.yaml.parameters[0].Version.default
   }
 
   components_aws_versions = {

--- a/teams/nomis/modules/imagebuilder/locals.tf
+++ b/teams/nomis/modules/imagebuilder/locals.tf
@@ -15,7 +15,7 @@ locals {
     for component_filename in var.image_recipe.components_custom :
     component_filename => yamldecode(
       length(regexall(".*tftpl", component_filename)) > 0 ?
-      templatefile(component_filename", local.component_template_args) :
+      templatefile(component_filename, local.component_template_args) :
       file(component_filename)
     )
   }

--- a/teams/nomis/modules/imagebuilder/locals.tf
+++ b/teams/nomis/modules/imagebuilder/locals.tf
@@ -36,8 +36,6 @@ locals {
     image-pipeline               = local.name
     image-recipe                 = join("/", [local.name, var.configuration_version])
     infrastructure-configuration = join("/", [local.name, var.configuration_version])
-    github-branch                = var.branch == "" ? "n/a" : var.branch
-    github-actor                 = var.gh_actor == "" ? "n/a" : var.gh_actor
     release-or-patch             = var.release_or_patch == "" ? "n/a" : var.release_or_patch
   }
 

--- a/teams/nomis/modules/imagebuilder/main.tf
+++ b/teams/nomis/modules/imagebuilder/main.tf
@@ -88,12 +88,23 @@ resource "aws_imagebuilder_distribution_configuration" "this" {
   distribution {
     region = var.region
 
-    ami_distribution_configuration {
-      name               = local.ami_name
-      description        = var.description
-      kms_key_id         = lookup(var.distribution_configuration.ami_distribution_configuration, "kms_key_id", var.kms_key_id)
-      target_account_ids = lookup(var.distribution_configuration.ami_distribution_configuration, "target_account_ids", null)
-      ami_tags           = local.ami_tags
+    dynamic "ami_distribution_configuration" {
+      for_each = try(var.distribution_configuration.ami_distribution_configuration, null) != null ? [var.distribution_configuration.ami_distribution_configuration] : []
+      content {
+        name               = local.ami_name
+        description        = var.description
+        kms_key_id         = var.kms_key_id
+        target_account_ids = flatten([for name in ami_distribution_configuration.value.target_account_ids_or_names : try(var.account_ids_lookup[name], name)])
+        ami_tags           = local.ami_tags
+      }
+    }
+
+    dynamic "launch_template_configuration" {
+      for_each = try(var.distribution_configuration.launch_template_configuration, null) != null ? [var.distribution_configuration.launch_template_configuration] : []
+      content {
+        account_id         = try(var.account_ids_lookup[launch_template_configuration.value.account_id_or_name], launch_template_configuration.value.account_id_or_name)
+        launch_template_id = launch_template_configuration.value.launch_template_id
+      }
     }
   }
 }

--- a/teams/nomis/modules/imagebuilder/main.tf
+++ b/teams/nomis/modules/imagebuilder/main.tf
@@ -89,7 +89,7 @@ resource "aws_imagebuilder_distribution_configuration" "this" {
     region = var.region
 
     dynamic "ami_distribution_configuration" {
-      for_each = try(var.distribution_configuration.ami_distribution_configuration, null) != null ? [var.distribution_configuration.ami_distribution_configuration] : []
+      for_each = [var.distribution_configuration.ami_distribution_configuration]
       content {
         name               = local.ami_name
         description        = var.description

--- a/teams/nomis/modules/imagebuilder/main.tf
+++ b/teams/nomis/modules/imagebuilder/main.tf
@@ -95,6 +95,9 @@ resource "aws_imagebuilder_distribution_configuration" "this" {
         description        = var.description
         kms_key_id         = var.kms_key_id
         target_account_ids = flatten([for name in ami_distribution_configuration.value.target_account_ids_or_names : try(var.account_ids_lookup[name], name)])
+        launch_permission {
+          user_ids = flatten([for name in ami_distribution_configuration.value.target_account_ids_or_names : try(var.account_ids_lookup[name], name)])
+        }
         ami_tags           = local.ami_tags
       }
     }

--- a/teams/nomis/modules/imagebuilder/main.tf
+++ b/teams/nomis/modules/imagebuilder/main.tf
@@ -1,11 +1,11 @@
 resource "aws_imagebuilder_component" "this" {
   for_each = local.components_custom_yaml
 
-  name        = each.value.name
-  description = each.value.description
-  platform    = each.value.parameters[1].Platform.default
-  version     = each.value.parameters[0].Version.default
-  data        = file(each.key)
+  name        = each.value.yaml.name
+  description = each.value.yaml.description
+  platform    = each.value.yaml.parameters[1].Platform.default
+  version     = each.value.yaml.parameters[0].Version.default
+  data        = each.value.raw
   kms_key_id  = var.kms_key_id
   tags        = local.tags
 
@@ -98,7 +98,7 @@ resource "aws_imagebuilder_distribution_configuration" "this" {
         launch_permission {
           user_ids = flatten([for name in ami_distribution_configuration.value.target_account_ids_or_names : try(var.account_ids_lookup[name], name)])
         }
-        ami_tags           = local.ami_tags
+        ami_tags = local.ami_tags
       }
     }
 

--- a/teams/nomis/modules/imagebuilder/variables.tf
+++ b/teams/nomis/modules/imagebuilder/variables.tf
@@ -73,8 +73,12 @@ variable "infrastructure_configuration" {
 variable "distribution_configuration" {
   type = object({
     ami_distribution_configuration = object({
-      target_account_ids = list(string)
+      target_account_ids_or_names = list(string)
     })
+    launch_template_configuration = optional(object({
+      account_id_or_name = string
+      launch_template_id = string
+    }))
   })
   description = "Distribution configuration, see aws_imagebuilder_distribution_configuration documentation for details on the parameters"
 }

--- a/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_6_10_baseimage = {
-    configuration_version = "0.1.7"
+    configuration_version = "0.1.8"
     description           = "nomis rhel 6.10 base image"
 
     tags = {

--- a/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_6_10_baseimage = {
-    configuration_version = "0.1.6"
+    configuration_version = "0.1.7"
     description           = "nomis rhel 6.10 base image"
 
     tags = {
@@ -54,15 +54,26 @@ EOF
   }
 }
 
-distribution_target_account_names_by_branch = {
-  main = [
-    "core-shared-services-production",
-    "nomis-test",
-    "nomis-development"
-  ]
-  default = [
-    "core-shared-services-production",
-    "nomis-test",
-    "nomis-development"
-  ]
+distribution_configuration_by_branch = {
+  # push to main branch
+  main = {
+    ami_distribution_configuration = {
+      target_account_ids_or_names = [
+        "core-shared-services-production",
+        "nomis-test",
+        "nomis-development"
+      ]
+    }
+  }
+
+  # push to any other branch / local run
+  default = {
+    ami_distribution_configuration = {
+      target_account_ids_or_names = [
+        "core-shared-services-production",
+        "nomis-test",
+        "nomis-development"
+      ]
+    }
+  }
 }

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
@@ -7,7 +7,7 @@ imagebuilders = {
   # test configuration
   # needs EBS and components adding
   rhel_6_10_weblogic_appserver_10_3 = {
-    configuration_version = "0.0.2"
+    configuration_version = "0.0.3"
     release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
     description           = "nomis rhel 6.10 weblogic appserver image"
 

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
@@ -53,14 +53,25 @@ imagebuilders = {
   }
 }
 
-distribution_target_account_names_by_branch = {
-  main = [
-    "core-shared-services-production",
-    "nomis-test",
-    "nomis-production"
-  ]
-  default = [
-    "core-shared-services-production",
-    "nomis-test"
-  ]
+distribution_configuration_by_branch = {
+  # push to main branch
+  main = {
+    ami_distribution_configuration = {
+      target_account_ids_or_names = [
+        "core-shared-services-production",
+        "nomis-test",
+        "nomis-production"
+      ]
+    }
+  }
+
+  # push to any other branch / local run
+  default = {
+    ami_distribution_configuration = {
+      target_account_ids_or_names = [
+        "core-shared-services-production",
+        "nomis-test"
+      ]
+    }
+  }
 }

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_7_9_baseimage = {
-    configuration_version = "1.2.4"
+    configuration_version = "1.2.5"
     description           = "nomis RHEL7.9 base image"
 
     tags = {

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_7_9_baseimage = {
-    configuration_version = "1.2.2"
+    configuration_version = "1.2.3"
     description           = "nomis RHEL7.9 base image"
 
     tags = {

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_7_9_baseimage = {
-    configuration_version = "1.2.5"
+    configuration_version = "1.2.6"
     description           = "nomis RHEL7.9 base image"
 
     tags = {
@@ -31,7 +31,7 @@ imagebuilders = {
         "amazon-cloudwatch-agent-linux"
       ]
       components_custom = [
-        "../components/rhel_7_9_baseimage/rhel_7_9_baseimage.yml.tmpl"
+        "../components/rhel_7_9_baseimage/rhel_7_9_baseimage.yml.tftpl"
       ]
     }
 

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_7_9_baseimage = {
-    configuration_version = "1.2.8"
+    configuration_version = "1.2.9"
     description           = "nomis RHEL7.9 base image"
 
     tags = {

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_7_9_baseimage = {
-    configuration_version = "1.2.6"
+    configuration_version = "1.2.7"
     description           = "nomis RHEL7.9 base image"
 
     tags = {

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_7_9_baseimage = {
-    configuration_version = "1.2.7"
+    configuration_version = "1.2.8"
     description           = "nomis RHEL7.9 base image"
 
     tags = {

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -47,13 +47,29 @@ imagebuilders = {
   }
 }
 
-distribution_target_account_names_by_branch = {
-  main = [
-    "core-shared-services-production",
-    "nomis-test"
-  ]
-  default = [
-    "core-shared-services-production",
-    "nomis-test"
-  ]
+distribution_configuration_by_branch = {
+  # push to main branch
+  main = {
+    ami_distribution_configuration = {
+      target_account_ids_or_names = [
+        "core-shared-services-production",
+        "nomis-test"
+       ]
+    }
+  }
+
+  # push to any other branch / local run
+  default = {
+    ami_distribution_configuration = {
+      target_account_ids_or_names = [
+        "core-shared-services-production",
+        "nomis-test"
+      ]
+    }
+
+    launch_template_configuration = {
+      account_id_or_name = "nomis-test"
+      launch_template_id = "lt-0b4eec79084daf59f"
+    }
+  }
 }

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_7_9_baseimage = {
-    configuration_version = "1.2.3"
+    configuration_version = "1.2.4"
     description           = "nomis RHEL7.9 base image"
 
     tags = {
@@ -69,7 +69,7 @@ distribution_configuration_by_branch = {
 
     launch_template_configuration = {
       account_id_or_name = "nomis-test"
-      launch_template_id = "lt-0b4eec79084daf59f"
+      launch_template_id = "lt-05c9663f629ff1ba8"
     }
   }
 }

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -54,7 +54,12 @@ distribution_configuration_by_branch = {
       target_account_ids_or_names = [
         "core-shared-services-production",
         "nomis-test"
-       ]
+      ]
+    }
+
+    launch_template_configuration = {
+      account_id_or_name = "nomis-test"
+      launch_template_id = "lt-05c9663f629ff1ba8"
     }
   }
 

--- a/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
@@ -7,7 +7,7 @@ imagebuilders = {
   # test configuration
   # needs EBS and components adding
   rhel_7_9_oracledb_11_2 = {
-    configuration_version = "0.0.5"
+    configuration_version = "0.0.6"
     release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
     description           = "nomis rhel 7.9 oracleDB 11.2 image"
 

--- a/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
@@ -80,7 +80,7 @@ imagebuilders = {
       ]
 
       components_custom = [
-        "../components/rhel_7_9_oracledb_11_2/database.yml.tmpl"
+        "../components/rhel_7_9_oracledb_11_2/database.yml.tftpl"
       ]
 
       components_aws = []

--- a/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
@@ -98,14 +98,25 @@ imagebuilders = {
   }
 }
 
-distribution_target_account_names_by_branch = {
-  main = [
-    "core-shared-services-production",
-    "nomis-test",
-    "nomis-production"
-  ]
-  default = [
-    "core-shared-services-production",
-    "nomis-test"
-  ]
+distribution_configuration_by_branch = {
+  # push to main branch
+  main = {
+    ami_distribution_configuration = {
+      target_account_ids_or_names = [
+        "core-shared-services-production",
+        "nomis-test",
+        "nomis-production"
+      ]
+    }
+  }
+
+  # push to any other branch / local run
+  default = {
+    ami_distribution_configuration = {
+      target_account_ids_or_names = [
+        "core-shared-services-production",
+        "nomis-test"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Fixed bug where the templated files weren't been used correctly.
Renamed the templated files to the terraform recommended extension
Reworked the distribution config to allow launch templates to be specified
Added launch template for RHEL7.9 base image
Updated Readme
Removed duplicate github-branch tag