### PR TITLE
DSOS-1493: Remove some public actions from nomis AMI pipeline

### DIFF
--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -373,7 +373,6 @@ jobs:
           comment >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
-      # security best practice: use specific version of public actions (v1.3.0)
       - name: Post Apply to PR
         run: |
           curl -X POST \

--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -112,17 +112,13 @@ jobs:
           echo ::set-output name=projects::${projects}
           echo ::set-output name=action::${action}
 
-      # # security best practice: use specific version of public actions (v1)
-      # - name: Get list of committed files
-      #   id: files
-      #   if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
-      #   uses: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42
-      #   with:
-      #     format: 'space-delimited'
-
+      # security best practice: use specific version of public actions (v1)
       - name: Get list of committed files
         id: files
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+        uses: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42
+        with:
+          format: 'space-delimited'
 
       - name: Detect pull/push projects
         id: projects_pull_push

--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -379,9 +379,13 @@ jobs:
 
       # security best practice: use specific version of public actions (v1.3.0)
       - name: Post Apply to PR
-        uses: thollander/actions-comment-pull-request@686ab1cab89e0f715a44a0d04b9fdfdd4f33d751
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${pr_number}/comments \
+            -d '{"body":'\"${message}\"'}'
         if: ${{ github.event_name == 'push' && steps.plan.outputs.exitcode == '2' }}
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        env:
           message: "${{ env.TF_APPLY_OUT }}"
           pr_number: "${{ needs.init.outputs.pr_number }}"

--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -73,14 +73,17 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v3
 
-      # get PR number on push v1.3.0
-      # security best practice: use specific version of public actions (v1.3.0)
+      # get PR number on push
       - name: Get PR number on push
-        uses: jwalton/gh-find-current-pr@e12d66bc9ecc4fdcde07b0f70a3cb68ce7e4d807
         id: get_pr_number
+        run: |
+          pr_number=$(curl \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls \
+            | jq -r '.[0].number')
+          echo ::set-output name=pr::${pr_number}
         if: ${{ github.event_name == 'push' }}
-        with:
-          state: all
 
       # for workflow dispatch, check valid project specified
       - name: Validate workflow dispatch
@@ -109,13 +112,17 @@ jobs:
           echo ::set-output name=projects::${projects}
           echo ::set-output name=action::${action}
 
-      # security best practice: use specific version of public actions (v1)
+      # # security best practice: use specific version of public actions (v1)
+      # - name: Get list of committed files
+      #   id: files
+      #   if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+      #   uses: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42
+      #   with:
+      #     format: 'space-delimited'
+
       - name: Get list of committed files
         id: files
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
-        uses: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42
-        with:
-          format: 'space-delimited'
 
       - name: Detect pull/push projects
         id: projects_pull_push


### PR DESCRIPTION
I'm replacing the public github actions `jwalton/gh-find-current-pr` & `actions-comment-pull-request` with custom actions based on direct GitHub API calls as advised by the mod-platform team. 