### PR TITLE
AMI target accounts

### DIFF
--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_7_9_baseimage = {
-    configuration_version = "1.3.9"
+    configuration_version = "1.4.0"
     description           = "nomis RHEL7.9 base image"
 
     tags = {
@@ -54,6 +54,7 @@ distribution_configuration_by_branch = {
   main = {
     ami_distribution_configuration = {
       target_account_ids_or_names = [
+        "core-shared-services-production"
         "nomis-development",
         "nomis-test"
       ]
@@ -69,6 +70,7 @@ distribution_configuration_by_branch = {
   default = {
     ami_distribution_configuration = {
       target_account_ids_or_names = [
+        "core-shared-services-production"
         "nomis-development",
         "nomis-test"
       ]

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -54,7 +54,8 @@ distribution_configuration_by_branch = {
   main = {
     ami_distribution_configuration = {
       target_account_ids_or_names = [
-        "nomis-development"
+        "nomis-development",
+        "nomis-test"
       ]
     }
 
@@ -68,7 +69,8 @@ distribution_configuration_by_branch = {
   default = {
     ami_distribution_configuration = {
       target_account_ids_or_names = [
-        "nomis-development"
+        "nomis-development",
+        "nomis-test"
       ]
     }
 

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -54,7 +54,7 @@ distribution_configuration_by_branch = {
   main = {
     ami_distribution_configuration = {
       target_account_ids_or_names = [
-        "core-shared-services-production"
+        "core-shared-services-production",
         "nomis-development",
         "nomis-test"
       ]
@@ -70,7 +70,7 @@ distribution_configuration_by_branch = {
   default = {
     ami_distribution_configuration = {
       target_account_ids_or_names = [
-        "core-shared-services-production"
+        "core-shared-services-production",
         "nomis-development",
         "nomis-test"
       ]


### PR DESCRIPTION
Re-added `nomis-test` to `target_account_ids` list.