### PR TITLE
add ListBuckets permissions to imageBuilder role

### DIFF
--- a/modernisation-platform/iam.tf
+++ b/modernisation-platform/iam.tf
@@ -45,6 +45,7 @@ resource "aws_iam_role" "image_builder_role" {
             Effect = "Allow"
             Resource = [
               "arn:aws:s3:::ec2-image-builder-*/*",
+              "arn:aws:s3:::ec2-image-builder-*",
             ]
           },
           {

--- a/modernisation-platform/iam.tf
+++ b/modernisation-platform/iam.tf
@@ -40,6 +40,7 @@ resource "aws_iam_role" "image_builder_role" {
             Action = [
               "s3:PutObject",
               "s3:GetObject",
+              "s3:ListBucket",
             ]
             Effect = "Allow"
             Resource = [


### PR DESCRIPTION
Need to add this permission to this role to allow the imagebuilder to access s3 buckets

This is in order to build an oracle database ami which already contains test data, rather than having to add this later