### PR TITLE
Remove scheduled scan from SCA

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -1,9 +1,6 @@
 name: Terraform Static Code Analysis
 
 on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron:  '0 7 * * 1-5'
   workflow_dispatch:
   pull_request:
     branches:
@@ -18,7 +15,7 @@ jobs:
   terraform-static-analysis:
     name: Terraform Static Analysis
     runs-on: ubuntu-latest
-    if: github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'
+    if: github.event_name != 'workflow_dispatch'
     steps:
     - name: Checkout
       uses: actions/checkout@v3.1.0
@@ -47,28 +44,3 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         scan_type: full
-
-  terraform-static-analysis-scheduled-scan:
-    name: Terraform Static Analysis - scheduled scan of all directories
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3.1.0
-      with:
-        fetch-depth: 0
-    - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@main
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        scan_type: full
-    - uses: 8398a7/action-slack@v3
-      name: Slack failure notification
-      with:
-        job_name: Terraform Static Analysis - scheduled scan of all directories
-        status: ${{ job.status }}
-        fields: workflow,job,repo,commit,message
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: ${{ failure() }}


### PR DESCRIPTION
The scheduled scan and notification was introduced on our main repo as we control all of the code and we wanted to have notification if there were SCA issues that needed to be address.  Since this repo has shared code of both MP and teams, a sheduled run offers little value as we are not enforcing SCA standards on users.  This would mean we get daily notifications when there are issues that we are not going to look at. Therefore removing the scheduled run from this workflow.