### PR TITLE
nomis: DSOS-1500: improve AMI scheduled builds

### DIFF
--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -76,6 +76,7 @@ jobs:
       # get PR number on push
       - name: Get PR number on push
         id: get_pr_number
+        if: ${{ github.event_name == 'push' }}
         run: |
           pr_number=$(curl \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -76,7 +76,6 @@ jobs:
       # get PR number on push
       - name: Get PR number on push
         id: get_pr_number
-        if: ${{ github.event_name == 'push' }}
         run: |
           pr_number=$(curl \
             -H "Accept: application/vnd.github+json" \

--- a/teams/nomis/main.tf
+++ b/teams/nomis/main.tf
@@ -104,3 +104,8 @@ module "imagebuilder" {
   branch                       = var.BRANCH_NAME
   gh_actor                     = var.GH_ACTOR_NAME
 }
+
+output "parent_ami" {
+  value       = module.imagebuilder.parent_ami
+  description = "parent AMI details, useful if looked up by a filter"
+}

--- a/teams/nomis/main.tf
+++ b/teams/nomis/main.tf
@@ -106,6 +106,6 @@ module "imagebuilder" {
 }
 
 output "parent_ami" {
-  value       = module.imagebuilder.parent_ami
+  value       = { for k in var.imagebuilders : k => module.imagebuilder[k].parent_ami }
   description = "parent AMI details, useful if looked up by a filter"
 }

--- a/teams/nomis/main.tf
+++ b/teams/nomis/main.tf
@@ -106,6 +106,6 @@ module "imagebuilder" {
 }
 
 output "parent_ami" {
-  value       = { for k in var.imagebuilders : k => module.imagebuilder[k].parent_ami }
+  value       = { for key, value in module.imagebuilder : key => value.parent_ami }
   description = "parent AMI details, useful if looked up by a filter"
 }

--- a/teams/nomis/main.tf
+++ b/teams/nomis/main.tf
@@ -107,5 +107,5 @@ module "imagebuilder" {
 
 output "parent_ami" {
   value       = { for key, value in module.imagebuilder : key => value.parent_ami }
-  description = "parent AMI details, useful if looked up by a filter"
+  description = "parent AMI details"
 }

--- a/teams/nomis/modules/imagebuilder/data.tf
+++ b/teams/nomis/modules/imagebuilder/data.tf
@@ -22,12 +22,12 @@ data "aws_imagebuilder_component" "this" {
 }
 
 data "aws_ami" "parent" {
+  count       = var.image_recipe.parent_image.filter_name_value != null ? 1 : 0
   most_recent = true
-  owners      = flatten([try(var.account_ids_lookup[var.image_recipe.parent_image.owner], var.image_recipe.parent_image.owner)])
+  owners      = local.ami_parent_id
 
   filter {
     name   = "name"
     values = [var.image_recipe.parent_image.filter_name_value]
   }
 }
-

--- a/teams/nomis/modules/imagebuilder/data.tf
+++ b/teams/nomis/modules/imagebuilder/data.tf
@@ -24,7 +24,7 @@ data "aws_imagebuilder_component" "this" {
 data "aws_ami" "parent" {
   count       = var.image_recipe.parent_image.filter_name_value != null ? 1 : 0
   most_recent = true
-  owners      = local.ami_parent_id
+  owners      = [local.ami_parent_id]
 
   filter {
     name   = "name"

--- a/teams/nomis/modules/imagebuilder/locals.tf
+++ b/teams/nomis/modules/imagebuilder/locals.tf
@@ -63,5 +63,8 @@ locals {
   ami_tags = merge(local.tags, {
     Name = local.ami_name
   })
+
+  ami_parent_id  = try(var.account_ids_lookup[var.image_recipe.parent_image.owner], var.image_recipe.parent_image.owner)
+  ami_parent_arn = try("arn:aws:imagebuilder:${var.region}:${local.ami_parent_id}:image/${var.image_recipe.parent_image.arn_resource_id}", null)
 }
 

--- a/teams/nomis/modules/imagebuilder/main.tf
+++ b/teams/nomis/modules/imagebuilder/main.tf
@@ -53,7 +53,7 @@ resource "aws_imagebuilder_image_recipe" "this" {
   }
 
   dynamic "systems_manager_agent" {
-    for_each = var.image_recipe.systems_manager_agent != null ? ["systems_manager_agent"] : []
+    for_each = var.image_recipe.systems_manager_agent != null ? [var.image_recipe.systems_manager_agent] : []
     content {
       uninstall_after_build = systems_manager_agent.value.uninstall_after_build
     }

--- a/teams/nomis/modules/imagebuilder/main.tf
+++ b/teams/nomis/modules/imagebuilder/main.tf
@@ -55,7 +55,7 @@ resource "aws_imagebuilder_image_recipe" "this" {
   dynamic "systems_manager_agent" {
     for_each = var.image_recipe.systems_manager_agent != null ? ["this"] : []
     content {
-      uninstall_after_build = systems_manager_agent.uninstall_after_build
+      uninstall_after_build = systems_manager_agent.value.uninstall_after_build
     }
   }
 

--- a/teams/nomis/modules/imagebuilder/main.tf
+++ b/teams/nomis/modules/imagebuilder/main.tf
@@ -16,7 +16,7 @@ resource "aws_imagebuilder_component" "this" {
 
 resource "aws_imagebuilder_image_recipe" "this" {
   name             = local.name
-  parent_image     = data.aws_ami.parent.id
+  parent_image     = try(data.aws_ami.parent[0].id, local.ami_parent_arn)
   version          = var.configuration_version
   description      = var.description
   user_data_base64 = try(base64encode(var.image_recipe.user_data), null)
@@ -52,15 +52,15 @@ resource "aws_imagebuilder_image_recipe" "this" {
     }
   }
 
-  lifecycle {
-    create_before_destroy = true
+  dynamic "systems_manager_agent" {
+    for_each = var.image_recipe.systems_manager_agent != null ? ["this"] : []
+    content {
+      uninstall_after_build = systems_manager_agent.uninstall_after_build
+    }
   }
 
-  dynamic "systems_manager_agent" {
-    for_each = data.aws_ami.parent.platform == "windows" ? [] : ["linux"]
-    content {
-      uninstall_after_build = false
-    }
+  lifecycle {
+    create_before_destroy = true
   }
 }
 

--- a/teams/nomis/modules/imagebuilder/main.tf
+++ b/teams/nomis/modules/imagebuilder/main.tf
@@ -53,7 +53,7 @@ resource "aws_imagebuilder_image_recipe" "this" {
   }
 
   dynamic "systems_manager_agent" {
-    for_each = var.image_recipe.systems_manager_agent != null ? ["this"] : []
+    for_each = var.image_recipe.systems_manager_agent != null ? ["systems_manager_agent"] : []
     content {
       uninstall_after_build = systems_manager_agent.value.uninstall_after_build
     }

--- a/teams/nomis/modules/imagebuilder/outputs.tf
+++ b/teams/nomis/modules/imagebuilder/outputs.tf
@@ -1,4 +1,6 @@
 output "parent_ami" {
-  value       = try(data.aws_ami.parent[0], {})
+  value = try(data.aws_ami.parent[0], {
+    arn = local.ami_parent_arn
+  })
   description = "parent AMI details, useful if looked up by a filter"
 }

--- a/teams/nomis/modules/imagebuilder/outputs.tf
+++ b/teams/nomis/modules/imagebuilder/outputs.tf
@@ -1,4 +1,6 @@
-output "parent_ami_arn" {
-  value       = try(data.aws_ami.parent[0].arn, local.ami_parent_arn)
-  description = "Map of common firewall policy rules"
+output "parent_ami" {
+  value = {
+    arn = try(data.aws_ami.parent[0].arn, local.ami_parent_arn)
+  }
+  description = "parent AMI details, useful if looked up by a filter"
 }

--- a/teams/nomis/modules/imagebuilder/outputs.tf
+++ b/teams/nomis/modules/imagebuilder/outputs.tf
@@ -1,6 +1,4 @@
 output "parent_ami" {
-  value = {
-    arn = try(data.aws_ami.parent[0].arn, local.ami_parent_arn)
-  }
+  value       = try(data.aws_ami.parent[0], {})
   description = "parent AMI details, useful if looked up by a filter"
 }

--- a/teams/nomis/modules/imagebuilder/outputs.tf
+++ b/teams/nomis/modules/imagebuilder/outputs.tf
@@ -1,0 +1,4 @@
+output "parent_ami_arn" {
+  value       = try(data.aws_ami.parent[0].arn, local.ami_parent_arn)
+  description = "Map of common firewall policy rules"
+}

--- a/teams/nomis/modules/imagebuilder/outputs.tf
+++ b/teams/nomis/modules/imagebuilder/outputs.tf
@@ -1,6 +1,6 @@
 output "parent_ami" {
   value = try(data.aws_ami.parent[0], {
-    arn = local.ami_parent_arn
+    descripion = "data.aws_ami output not provided when ARN used to specify parent"
   })
-  description = "parent AMI details, useful if looked up by a filter"
+  description = "parent AMI details from aws_ami name filter lookup"
 }

--- a/teams/nomis/modules/imagebuilder/variables.tf
+++ b/teams/nomis/modules/imagebuilder/variables.tf
@@ -49,8 +49,9 @@ variable "account_ids_lookup" {
 variable "image_recipe" {
   type = object({
     parent_image = object({
-      owner             = string # either an ID or a name which is a key in var.account_ids_lookup
-      filter_name_value = string
+      owner             = string           # either an ID or a name which is a key in var.account_ids_lookup
+      filter_name_value = optional(string) # either lookup via AMI name
+      arn_resource_id   = optional(string) # or specify an AMI ARN directly (the last part of ARN after arm:aws:imagebuilder:{region}:{account-id}:image/)
     })
     user_data = optional(string)
     block_device_mappings_ebs = list(object({
@@ -60,6 +61,9 @@ variable "image_recipe" {
     }))
     components_aws    = list(string)
     components_custom = list(string)
+    systems_manager_agent = optional(object({
+      uninstall_after_build = bool
+    }))
   })
   description = "Details of image builder recipe, see aws_imagebuilder_image_recipe documentation for details on the parameters"
 }

--- a/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_6_10_baseimage = {
-    configuration_version = "0.3.3"
+    configuration_version = "0.3.4"
     description           = "nomis RHEL6.10 base image"
 
     tags = {
@@ -44,6 +44,10 @@ sudo start amazon-ssm-agent
 wget https://s3.eu-west-2.amazonaws.com/amazoncloudwatch-agent-eu-west-2/redhat/amd64/latest/amazon-cloudwatch-agent.rpm
 sudo rpm -U ./amazon-cloudwatch-agent.rpm
 EOF
+
+      systems_manager_agent = {
+        uninstall_after_build = false
+      }
     }
 
     infrastructure_configuration = {

--- a/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_6_10_baseimage = {
-    configuration_version = "0.3.4"
+    configuration_version = "0.3.5"
     description           = "nomis RHEL6.10 base image"
 
     tags = {

--- a/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
@@ -14,6 +14,9 @@ imagebuilders = {
 
     image_recipe = {
       parent_image = {
+        # NOTE: this picks up the latest RHEL image at the time the terraform
+        # is run.  Increment version number and re-run the pipeline when a new
+        # version is released by RedHat.
         owner             = "309956199498" # Redhat
         filter_name_value = "RHEL-6.10_HVM-*"
       }

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
@@ -18,7 +18,7 @@ imagebuilders = {
     image_recipe = {
       parent_image = {
         owner             = "core-shared-services-production"
-        arn_resource_id   = "nomis_rhel_6_10_baseimage/x.x.x"
+        arn_resource_id   = "nomis_rhel_6_10_baseimage/x.x.x/x"
       }
 
       block_device_mappings_ebs = [

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
@@ -7,7 +7,7 @@ imagebuilders = {
   # test configuration
   # needs EBS and components adding
   rhel_6_10_weblogic_appserver_10_3 = {
-    configuration_version = "0.1.1"
+    configuration_version = "0.1.2"
     release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
     description           = "nomis rhel 6.10 weblogic appserver image"
 
@@ -18,7 +18,7 @@ imagebuilders = {
     image_recipe = {
       parent_image = {
         owner             = "core-shared-services-production"
-        filter_name_value = "nomis_rhel_6_10_baseimage_*"
+        arn_resource_id   = "nomis_rhel_6_10_baseimage/x.x.x"
       }
 
       block_device_mappings_ebs = [
@@ -43,6 +43,9 @@ imagebuilders = {
         "../components/rhel_6_10_weblogic_appserver_10_3/weblogic.yml"
       ]
 
+      systems_manager_agent = {
+        uninstall_after_build = false
+      }
     }
 
     infrastructure_configuration = {

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
@@ -7,7 +7,7 @@ imagebuilders = {
   # test configuration
   # needs EBS and components adding
   rhel_6_10_weblogic_appserver_10_3 = {
-    configuration_version = "0.1.2"
+    configuration_version = "0.1.3"
     release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
     description           = "nomis rhel 6.10 weblogic appserver image"
 

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
@@ -18,7 +18,7 @@ imagebuilders = {
     image_recipe = {
       parent_image = {
         owner             = "core-shared-services-production"
-        arn_resource_id   = "nomis_rhel_6_10_baseimage/x.x.x/x"
+        arn_resource_id   = "nomis_rhel_6_10_baseimage/0.3.3"
       }
 
       block_device_mappings_ebs = [

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
@@ -17,8 +17,8 @@ imagebuilders = {
 
     image_recipe = {
       parent_image = {
-        owner             = "core-shared-services-production"
-        arn_resource_id   = "nomis_rhel_6_10_baseimage/0.3.3"
+        owner           = "core-shared-services-production"
+        arn_resource_id = "nomis-rhel-6-10-baseimage/x.x.x"
       }
 
       block_device_mappings_ebs = [

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -14,8 +14,9 @@ imagebuilders = {
 
     image_recipe = {
       parent_image = {
-        owner             = "309956199498" # Redhat
-        filter_name_value = "RHEL-7.9_HVM-*"
+        owner = "309956199498" # Redhat
+        # filter_name_value = "RHEL-7.9_HVM-*"
+        arn_resource_id = "RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2/x.x.x"
       }
       block_device_mappings_ebs = [
         {

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -14,6 +14,9 @@ imagebuilders = {
 
     image_recipe = {
       parent_image = {
+        # NOTE: this picks up the latest RHEL image at the time the terraform
+        # is run.  Increment version number and re-run the pipeline when a new
+        # version is released by RedHat.
         owner             = "309956199498" # Redhat
         filter_name_value = "RHEL-7.9_HVM-*"
       }

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_7_9_baseimage = {
-    configuration_version = "1.4.1"
+    configuration_version = "1.4.2"
     description           = "nomis RHEL7.9 base image"
 
     tags = {
@@ -35,6 +35,9 @@ imagebuilders = {
         "../components/rhel_7_9_baseimage/python.yml",
         "../components/ansible.yml.tftpl"
       ]
+      systems_manager_agent = {
+        uninstall_after_build = false
+      }
     }
 
     infrastructure_configuration = {

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_7_9_baseimage = {
-    configuration_version = "1.4.2"
+    configuration_version = "1.4.3"
     description           = "nomis RHEL7.9 base image"
 
     tags = {

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -14,9 +14,8 @@ imagebuilders = {
 
     image_recipe = {
       parent_image = {
-        owner = "309956199498" # Redhat
-        # filter_name_value = "RHEL-7.9_HVM-*"
-        arn_resource_id = "RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2/x.x.x"
+        owner             = "309956199498" # Redhat
+        filter_name_value = "RHEL-7.9_HVM-*"
       }
       block_device_mappings_ebs = [
         {

--- a/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
@@ -15,9 +15,8 @@ imagebuilders = {
 
     image_recipe = {
       parent_image = {
-        platform          = "linux"
         owner             = "core-shared-services-production"
-        arn_resource_id   = "nomis_rhel_7_9_baseimage/x.x.x"
+        arn_resource_id   = "nomis-rhel-7-9-baseimage/x.x.x"
       }
 
       block_device_mappings_ebs = [

--- a/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_7_9_oracledb_11_2 = {
-    configuration_version = "0.2.2"
+    configuration_version = "0.2.3"
     release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
     description           = "nomis rhel 7.9 oracleDB 11.2 image"
 

--- a/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_7_9_oracledb_11_2 = {
-    configuration_version = "0.2.1"
+    configuration_version = "0.2.2"
     release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
     description           = "nomis rhel 7.9 oracleDB 11.2 image"
 
@@ -15,8 +15,9 @@ imagebuilders = {
 
     image_recipe = {
       parent_image = {
+        platform          = "linux"
         owner             = "core-shared-services-production"
-        filter_name_value = "nomis_rhel_7_9_baseimage_*"
+        arn_resource_id   = "nomis_rhel_7_9_baseimage/x.x.x"
       }
 
       block_device_mappings_ebs = [
@@ -84,6 +85,10 @@ imagebuilders = {
       components_custom = [
         "../components/ansible.yml.tftpl"
       ]
+
+      systems_manager_agent = {
+        uninstall_after_build = false
+      }
     }
 
     infrastructure_configuration = {

--- a/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
+++ b/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   windows_server_2022_jumpserver = {
-    configuration_version = "0.0.5"
+    configuration_version = "0.0.6"
     description           = "Windows Server 2022 jumpserver"
 
     tags = {

--- a/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
+++ b/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   windows_server_2022_jumpserver = {
-    configuration_version = "0.0.4"
+    configuration_version = "0.0.5"
     description           = "Windows Server 2022 jumpserver"
 
     tags = {
@@ -15,7 +15,7 @@ imagebuilders = {
     image_recipe = {
       parent_image = {
         owner             = "core-shared-services-production"
-        filter_name_value = "mp_WindowsServer2022_*"
+        arn_resource_id   = "mp-windowsserver2022/x.x.x"
       }
       block_device_mappings_ebs = [
         {


### PR DESCRIPTION
Allow Parent AMI to be referenced by ARN with version "x.x.x".  This ensures the latest version of the AMI is picked up when the pipeline is run.  Previously, the version was fixed to the AMI looked up when the terraform was run.

Changes:
- include the parent AMI details in the terraform output
- allow parent AMI to be looked up by ARN
- reworked the systems_manager_agent block as this can no longer be automatically derived from parent AMI
