### PR TITLE
nomis: DSOS-1524: pipeline fixes

### DIFF
--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -24,16 +24,16 @@ on:
         required: true
         default: 'plan'
 
-  pull_request:
-    types:
-      - opened
-      - edited
-      - synchronize
-      - reopened
-    branches:
-      - main
-    paths:
-      - teams/nomis/**
+        #  pull_request:
+        #    types:
+        #      - opened
+        #      - edited
+        #      - synchronize
+        #      - reopened
+        #    branches:
+        #      - main
+        #    paths:
+        #      - teams/nomis/**
 
   push:
     branches:

--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -77,13 +77,13 @@ jobs:
       - name: Get PR number on push
         id: get_pr_number
         run: |
-          echo "${{ github.repository }}"
-          echo "${{ github.head_ref }}"
+          echo "repo=${{ github.repository }} head_ref=${{ github.head_ref }} sha=${{ github.sha }}"
           pr_number=$(curl \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            https://api.github.com/repos/${{ github.repository }}/commits/${{ github.head_ref }}/pulls \
+            https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls \
             | jq -r '.[0].number')
+          echo "pr_number=${pr_number}"
           echo ::set-output name=pr::${pr_number}
 
       # for workflow dispatch, check valid project specified

--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -73,17 +73,20 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v3.1.0
 
-      # get PR number on push
+      # get PR number: for posting PR comments and figuring out changed
       - name: Get PR number on push
         id: get_pr_number
+        if: ${{ github.event_name == 'push' }}
         run: |
-          echo "repo=${{ github.repository }} head_ref=${{ github.head_ref }} sha=${{ github.sha }}"
           pr_number=$(curl \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls \
             | jq -r '.[0].number')
-          echo "pr_number=${pr_number}"
+          if [[ $pr_number == "null" ]]; then
+            echo "Could not find PR number for commit=${{ github.sha }}"
+            exit 1
+          fi
           echo ::set-output name=pr::${pr_number}
 
       # for workflow dispatch, check valid project specified
@@ -117,10 +120,18 @@ jobs:
         id: files
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
         run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            pr_number="${{ github.event.pull_request.number }}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            pr_number="${{ steps.get_pr_number.outputs.pr }}"
+          else
+            echo "Unexpected github event name ${GITHUB_EVENT_NAME}"
+            exit 1
+          fi
           pr_files=$(curl \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          https://api.github.com/repos/${{ github.repository }}/pulls/${{ steps.get_pr_number.outputs.pr }}/files \
+          https://api.github.com/repos/${{ github.repository }}/pulls/${pr_number}/files \
           | jq .[].filename \
           | sed 's/"//g' \
           | tr '\n' ' ')

--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -36,11 +36,11 @@ on:
         #      - teams/nomis/**
 
   push:
-    branches:
-      - main
-      - nomis/DSOS-1524/pipeline-fix
-    paths:
-      - teams/nomis/**
+    #    branches:
+    #      - main
+    #      - nomis/DSOS-1524/pipeline-fix
+    #    paths:
+    #      - teams/nomis/**
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v3.1.0
 
-      # get PR number: for posting PR comments and figuring out changed
+      # get PR number: for posting PR comments and figuring out changed files
       - name: Get PR number on push
         id: get_pr_number
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -164,11 +164,7 @@ jobs:
           elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
             projects="${{ steps.projects_pull_push.outputs.projects }}"
             pr_number="${{ steps.get_pr_number.outputs.pr }}"
-            if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-              action="apply"
-            else
-              action="plan"
-            fi
+            action="apply"
           else
             echo "Unsupported event ${GITHUB_EVENT_NAME}"
             exit 1

--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -38,6 +38,7 @@ on:
   push:
     branches:
       - main
+      - nomis/DSOS-1524/pipeline-fix
     paths:
       - teams/nomis/**
 
@@ -164,7 +165,11 @@ jobs:
           elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
             projects="${{ steps.projects_pull_push.outputs.projects }}"
             pr_number="${{ steps.get_pr_number.outputs.pr }}"
-            action="apply"
+            if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+              action="apply"
+            else
+              action="plan"
+            fi
           else
             echo "Unsupported event ${GITHUB_EVENT_NAME}"
             exit 1

--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -77,6 +77,8 @@ jobs:
       - name: Get PR number on push
         id: get_pr_number
         run: |
+          echo "${{ github.repository }}"
+          echo "${{ github.head_ref }}"
           pr_number=$(curl \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \

--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -24,23 +24,22 @@ on:
         required: true
         default: 'plan'
 
-        #  pull_request:
-        #    types:
-        #      - opened
-        #      - edited
-        #      - synchronize
-        #      - reopened
-        #    branches:
-        #      - main
-        #    paths:
-        #      - teams/nomis/**
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+    branches:
+      - main
+    paths:
+      - teams/nomis/**
 
   push:
-    #    branches:
-    #      - main
-    #      - nomis/DSOS-1524/pipeline-fix
-    #    paths:
-    #      - teams/nomis/**
+    branches:
+      - main
+    paths:
+      - teams/nomis/**
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -79,7 +79,7 @@ jobs:
         id: get_pr_number
         if: ${{ github.event_name == 'push' }}
         run: |
-          pr_number=$(curl \
+          pr_number=$(curl -sS \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls \
@@ -129,7 +129,7 @@ jobs:
             echo "Unexpected github event name ${GITHUB_EVENT_NAME}"
             exit 1
           fi
-          pr_files=$(curl \
+          pr_files=$(curl -sS \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           https://api.github.com/repos/${{ github.repository }}/pulls/${pr_number}/files \

--- a/teams/nomis/rhel_6_10_baseimage/backend.tf
+++ b/teams/nomis/rhel_6_10_baseimage/backend.tf
@@ -1,5 +1,4 @@
 # Backend
-
 terraform {
   # `backend` blocks do not support variables, so the following are hard-coded here:
   # - S3 bucket name, which is created in modernisation-platform-account/s3.tf

--- a/teams/nomis/rhel_6_10_baseimage/backend.tf
+++ b/teams/nomis/rhel_6_10_baseimage/backend.tf
@@ -1,4 +1,5 @@
 # Backend
+
 terraform {
   # `backend` blocks do not support variables, so the following are hard-coded here:
   # - S3 bucket name, which is created in modernisation-platform-account/s3.tf


### PR DESCRIPTION
Fixing some issues with the github API calls.  Tested this by temporarily allowing the pipeline to be triggered on a push from branches other than main.
- only try and figure out PR number on a push.  It was failing on manual dispatch, and a github var can be used if it's a PR
- use a SHA for the pulls API rather than head_ref, since that's what is in the documentation