### PR TITLE
nomis: DSOS-1500: remove AMI copying to other accounts

### DIFF
--- a/teams/nomis/modules/imagebuilder/main.tf
+++ b/teams/nomis/modules/imagebuilder/main.tf
@@ -97,9 +97,9 @@ resource "aws_imagebuilder_distribution_configuration" "this" {
         name               = local.ami_name
         description        = var.description
         kms_key_id         = var.kms_key_id
-        target_account_ids = flatten([for name in ami_distribution_configuration.value.target_account_ids_or_names : try(var.account_ids_lookup[name], name)])
+        target_account_ids = flatten([for name in ami_distribution_configuration.value.target_account_names : var.account_ids_lookup[name]])
         launch_permission {
-          user_ids = flatten([for name in ami_distribution_configuration.value.target_account_ids_or_names : try(var.account_ids_lookup[name], name)])
+          user_ids = flatten([for name in ami_distribution_configuration.value.launch_permission_account_names : var.account_ids_lookup[name]])
         }
         ami_tags = local.ami_tags
       }
@@ -108,7 +108,7 @@ resource "aws_imagebuilder_distribution_configuration" "this" {
     dynamic "launch_template_configuration" {
       for_each = try(var.distribution_configuration.launch_template_configuration, null) != null ? [var.distribution_configuration.launch_template_configuration] : []
       content {
-        account_id         = try(var.account_ids_lookup[launch_template_configuration.value.account_id_or_name], launch_template_configuration.value.account_id_or_name)
+        account_id         = var.account_ids_lookup[launch_template_configuration.value.account_name]
         launch_template_id = launch_template_configuration.value.launch_template_id
       }
     }

--- a/teams/nomis/modules/imagebuilder/variables.tf
+++ b/teams/nomis/modules/imagebuilder/variables.tf
@@ -78,10 +78,11 @@ variable "infrastructure_configuration" {
 variable "distribution_configuration" {
   type = object({
     ami_distribution_configuration = object({
-      target_account_ids_or_names = list(string)
+      target_account_names            = list(string)
+      launch_permission_account_names = list(string)
     })
     launch_template_configuration = optional(object({
-      account_id_or_name = string
+      account_name       = string
       launch_template_id = string
     }))
   })

--- a/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_6_10_baseimage = {
-    configuration_version = "0.3.6"
+    configuration_version = "0.3.8"
     description           = "nomis RHEL6.10 base image"
 
     tags = {

--- a/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_6_10_baseimage = {
-    configuration_version = "0.3.5"
+    configuration_version = "0.3.6"
     description           = "nomis RHEL6.10 base image"
 
     tags = {

--- a/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_baseimage/terraform.tfvars
@@ -68,32 +68,22 @@ EOF
 }
 
 distribution_configuration_by_branch = {
-  # push to main branch
-  main = {
-    ami_distribution_configuration = {
-      target_account_ids_or_names = [
-        "core-shared-services-production",
-        "nomis-development"
-      ]
-    }
-
-    launch_template_configuration = {
-      account_id_or_name = "nomis-development"
-      launch_template_id = "lt-04af9b9914ae9a578"
-    }
-  }
-
-  # push to any other branch / local run
   default = {
     ami_distribution_configuration = {
-      target_account_ids_or_names = [
+      target_account_names = [
+        "core-shared-services-production"
+      ]
+      launch_permission_account_names = [
         "core-shared-services-production",
-        "nomis-development"
+        "nomis-development",
+        "nomis-test",
+        "oasys-development",
+        "oasys-test"
       ]
     }
 
     launch_template_configuration = {
-      account_id_or_name = "nomis-development"
+      account_name       = "nomis-development"
       launch_template_id = "lt-04af9b9914ae9a578"
     }
   }

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
@@ -7,7 +7,7 @@ imagebuilders = {
   # test configuration
   # needs EBS and components adding
   rhel_6_10_weblogic_appserver_10_3 = {
-    configuration_version = "0.1.3"
+    configuration_version = "0.1.4"
     release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
     description           = "nomis rhel 6.10 weblogic appserver image"
 
@@ -64,9 +64,14 @@ distribution_configuration_by_branch = {
   # push to main branch
   main = {
     ami_distribution_configuration = {
-      target_account_ids_or_names = [
+      target_account_names = [
+        "core-shared-services-production"
+      ]
+      launch_permission_account_names = [
         "core-shared-services-production",
+        "nomis-development",
         "nomis-test",
+        "nomis-preproduction",
         "nomis-production"
       ]
     }
@@ -75,8 +80,12 @@ distribution_configuration_by_branch = {
   # push to any other branch / local run
   default = {
     ami_distribution_configuration = {
-      target_account_ids_or_names = [
+      target_account_names = [
+        "core-shared-services-production"
+      ]
+      launch_permission_account_names = [
         "core-shared-services-production",
+        "nomis-development",
         "nomis-test"
       ]
     }

--- a/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_baseimage/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_7_9_baseimage = {
-    configuration_version = "1.4.3"
+    configuration_version = "1.4.4"
     description           = "nomis RHEL7.9 base image"
 
     tags = {
@@ -58,32 +58,22 @@ imagebuilders = {
 }
 
 distribution_configuration_by_branch = {
-  # push to main branch
-  main = {
-    ami_distribution_configuration = {
-      target_account_ids_or_names = [
-        "core-shared-services-production",
-        "nomis-development"
-      ]
-    }
-
-    launch_template_configuration = {
-      account_id_or_name = "nomis-development"
-      launch_template_id = "lt-0ffc91d476d458bbc"
-    }
-  }
-
-  # push to any other branch / local run
   default = {
     ami_distribution_configuration = {
-      target_account_ids_or_names = [
+      target_account_names = [
+        "core-shared-services-production"
+      ]
+      launch_permission_account_names = [
         "core-shared-services-production",
-        "nomis-development"
+        "nomis-development",
+        "nomis-test",
+        "oasys-development",
+        "oasys-test"
       ]
     }
 
     launch_template_configuration = {
-      account_id_or_name = "nomis-development"
+      account_name       = "nomis-development"
       launch_template_id = "lt-0ffc91d476d458bbc"
     }
   }

--- a/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   rhel_7_9_oracledb_11_2 = {
-    configuration_version = "0.2.3"
+    configuration_version = "0.2.4"
     release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
     description           = "nomis rhel 7.9 oracleDB 11.2 image"
 
@@ -106,7 +106,10 @@ distribution_configuration_by_branch = {
   # push to main branch
   main = {
     ami_distribution_configuration = {
-      target_account_ids_or_names = [
+      target_account_names = [
+        "core-shared-services-production"
+      ]
+      launch_permission_account_names = [
         "core-shared-services-production",
         "nomis-development",
         "nomis-test",
@@ -119,7 +122,10 @@ distribution_configuration_by_branch = {
   # push to any other branch / local run
   default = {
     ami_distribution_configuration = {
-      target_account_ids_or_names = [
+      target_account_names = [
+        "core-shared-services-production"
+      ]
+      launch_permission_account_names = [
         "core-shared-services-production",
         "nomis-development",
         "nomis-test"

--- a/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
+++ b/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   windows_server_2022_jumpserver = {
-    configuration_version = "0.0.6"
+    configuration_version = "0.0.7"
     description           = "Windows Server 2022 jumpserver"
 
     tags = {
@@ -50,36 +50,37 @@ distribution_configuration_by_branch = {
   # push to main branch
   main = {
     ami_distribution_configuration = {
-      target_account_ids_or_names = [
+      target_account_names = [
+        "core-shared-services-production"
+      ]
+      launch_permission_account_names = [
         "core-shared-services-production",
         "nomis-development",
         "nomis-test",
+        "nomis-preproduction",
         "nomis-production",
-        "nomis-preproduction"
+        "oasys-development",
+        "oasys-test",
+        "oasys-preproduction",
+        "oasys-production"
       ]
-    }
-
-    launch_template_configuration = {
-      account_id_or_name = "nomis-test"
-      launch_template_id = "lt-0b4eec79084daf59f"
     }
   }
 
   # push to any other branch / local run
   default = {
     ami_distribution_configuration = {
-      target_account_ids_or_names = [
+      target_account_names = [
+        "core-shared-services-production"
+      ]
+      launch_permission_account_names = [
         "core-shared-services-production",
         "nomis-development",
         "nomis-test",
-        "nomis-production",
-        "nomis-preproduction"
+        "oasys-development",
+        "oasys-test"
       ]
     }
-
-    launch_template_configuration = {
-      account_id_or_name = "nomis-test"
-      launch_template_id = "lt-0b4eec79084daf59f"
-    }
   }
+
 }


### PR DESCRIPTION
Instead of copying AMIs to all accounts, just allow EC2s to launch referencing the AMI in core-shared-services-production.  This has been tested already with rhel79 base and oracle images.  

Changes are:
- add additional launch_permission_account_names parameter
- tweaked variable naming, we will always use account names instead of ids
- increment all versions
- updated the distribution settings for all pipelines including oasys for base images.