### PR TITLE
Nomis/powershell core on jumpserver ami

### DIFF
--- a/teams/nomis/components/windows_server_2022_jumpserver/powershell_core.yml
+++ b/teams/nomis/components/windows_server_2022_jumpserver/powershell_core.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.1
+      default: 0.0.2
       description: Component version (update this each time the file changes)
   - Platform:
       type: string

--- a/teams/nomis/components/windows_server_2022_jumpserver/powershell_core.yml
+++ b/teams/nomis/components/windows_server_2022_jumpserver/powershell_core.yml
@@ -1,0 +1,28 @@
+---
+name: UpgradeToPowerShellCore
+description: Component to upgrade to using PowerShell Core
+schemaVersion: 1.0
+parameters:
+  - Version:
+      type: string
+      default: 0.0.1
+      description: Component version (update this each time the file changes)
+  - Platform:
+      type: string
+      default: "Windows"
+      description: Platform.
+  - PowerShellCoreVersion:
+      type: string
+      default: 7.3.0
+      description: Version of the PowerShell Core to install
+phases:
+  - name: build
+    steps:
+      - name: InstallPowerShellCore
+        action: ExecutePowerShell
+        inputs:
+          commands:
+            - |
+              choco install -y chocolatey-core.extension
+              choco install -y kb3118401
+              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 REGISTER_MANIFEST=1 ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL=1"'

--- a/teams/nomis/components/windows_server_2022_jumpserver/powershell_core.yml
+++ b/teams/nomis/components/windows_server_2022_jumpserver/powershell_core.yml
@@ -26,3 +26,4 @@ phases:
               choco install -y chocolatey-core.extension
               choco install -y kb3118401
               choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 REGISTER_MANIFEST=1 ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL=1"'
+              Set-ItemProperty -Path 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\WinLogon' -Name Shell -Value 'C:\Program Files\Powershell\7\pwsh.exe' -ErrorAction Stop

--- a/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
+++ b/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
@@ -29,6 +29,7 @@ imagebuilders = {
         "ec2launch-v2-windows"
       ]
       components_custom = [
+        "../components/windows_server_2022_jumpserver/powershell_core.yml",
         "../components/windows_server_2022_jumpserver/prometheus_windows_exporter.yml",
         "../components/windows_server_2022_jumpserver/jumpserver.yml"
       ]

--- a/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
+++ b/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   windows_server_2022_jumpserver = {
-    configuration_version = "0.0.8"
+    configuration_version = "0.0.9"
     description           = "Windows Server 2022 jumpserver"
 
     tags = {

--- a/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
+++ b/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
@@ -5,7 +5,7 @@
 imagebuilders = {
 
   windows_server_2022_jumpserver = {
-    configuration_version = "0.0.7"
+    configuration_version = "0.0.8"
     description           = "Windows Server 2022 jumpserver"
 
     tags = {


### PR DESCRIPTION
Installs a (specified) version of powershell-core on the windows jumpservers which (sadly) only ship with PowerShell 5.1 (releasd 2016) which is a bit limiting when you're trying to debug/change things via ssm

Also makes PowerShell-Core the default shell and adds a bunch of context/right click menus so this is easy to find if you're connected to this via RDP