### PR TITLE
Nomis: DSOS-1613: redhat base image tweaks

### DIFF
--- a/commonimages/base/components/rhel_6_10/stig_rhel6_ansible.yml.tftpl
+++ b/commonimages/base/components/rhel_6_10/stig_rhel6_ansible.yml.tftpl
@@ -21,64 +21,71 @@ phases:
           commands:
             - |
               set -e
-              repo="modernisation-platform-ami-builds"
-              ami_tag="${ami}"
+              PATH=$PATH:/usr/local/bin
+              run_ansible() {
+                repo="modernisation-platform-ami-builds"
+                ami_tag="${ami}"
 
-              # clone ansible roles and playbook
-              ansible_dir=$(mktemp -d)
-              echo "Cloning $repo into $ansible_dir using branch=${branch}"
-              cd $ansible_dir
-              git clone -b ${branch} "https://github.com/ministryofjustice/$repo.git"
+                # clone ansible roles and playbook
+                yum install -y git
+                ansible_dir=$(mktemp -d)
+                echo "Cloning $repo into $ansible_dir using branch=${branch}"
+                cd $ansible_dir
+                git clone -b ${branch} "https://github.com/ministryofjustice/$repo.git"
 
-              # set python version
-              if [[ $(which python3.9) ]]; then
-                python=$(which python3.9)
-              elif [[ $(which python3.6) ]]; then
-                python=$(which python3.6)
-              else
-                echo "Python3.9/3.6 not found"
-                exit 1
-              fi
-              echo "python: $python"
+                # set python version
+                if [[ $(which python3.9) ]]; then
+                  python=$(which python3.9)
+                elif [[ $(which python3.6) ]]; then
+                  python=$(which python3.6)
+                else
+                  echo "Python3.9/3.6 not found"
+                  exit 1
+                fi
+                echo "python: $python"
 
-              # install python dependencies outside of virtual env so ansible
-              # can be executed remotely
-              cd $ansible_dir/$repo/ansible
-              $python -m pip install -r requirements.txt
+                # install python dependencies outside of virtual env so ansible
+                # can be executed remotely
+                cd $ansible_dir/$repo/ansible
+                $python -m pip install -r requirements.txt
 
-              # activate virtual environment
-              mkdir $ansible_dir/python-venv && cd "$_"
-              $python -m venv ansible
-              source ansible/bin/activate
-              $python -m pip install --upgrade pip
-              if [[ "$python" =~ 3.6 ]]; then
-                $python -m pip install wheel
-                $python -m pip install cryptography==2.3
-                export LC_ALL=en_US.UTF-8
-                $python -m pip install ansible-core==2.11.12
-              else
-                $python -m pip install ansible==6.0.0
-              fi
+                # activate virtual environment
+                mkdir $ansible_dir/python-venv && cd "$_"
+                $python -m venv ansible
+                source ansible/bin/activate
+                $python -m pip install --upgrade pip
+                if [[ "$python" =~ 3.6 ]]; then
+                  $python -m pip install wheel
+                  $python -m pip install cryptography==2.3
+                  export LC_ALL=en_US.UTF-8
+                  $python -m pip install ansible-core==2.11.12
+                else
+                  $python -m pip install ansible==6.0.0
+                fi
 
-              # install requirements in virtual env
-              cd $ansible_dir/$repo/ansible
-              $python -m pip install -r requirements.txt
-              ansible-galaxy role install -r requirements.yml
-              ansible-galaxy collection install -r requirements.yml --force
+                # install requirements in virtual env
+                cd $ansible_dir/$repo/ansible
+                $python -m pip install -r requirements.txt
+                ansible-galaxy role install -r requirements.yml
+                ansible-galaxy collection install -r requirements.yml --force
 
-              # run ansible (note comma after localhost is deliberate)
-              ansible-playbook -v playbooks/stig_rhel6.yml \
-              --connection=local \
-              --inventory localhost, \
-              --extra-vars "ansible_python_interpreter=$python" \
-              --extra-vars "target=localhost" \
-              --tags "amibuild,prelim,cat1,cat2" \
-              --skip-tags "low,aide,sshd,selinux,V-38484,V-38497,V-38518,V-38519,V-38585,V-38623,V-51337" \
-              --become
+                # run ansible (note comma after localhost is deliberate)
+                ansible-playbook -v playbooks/stig_rhel6.yml \
+                --connection=local \
+                --inventory localhost, \
+                --extra-vars "ansible_python_interpreter=$python" \
+                --extra-vars "target=localhost" \
+                --tags "amibuild,prelim,cat1,cat2" \
+                --skip-tags "low,aide,sshd,selinux,V-38484,V-38497,V-38518,V-38519,V-38585,V-38623,V-51337" \
+                --become
 
-              # Cleanup
-              deactivate
-              echo "Cleaning up $ansible_dir"
-              rm -rf $ansible_dir/$repo
-              rm -rf $ansible_dir/python-venv
-              rmdir $ansible_dir
+                # Cleanup
+                deactivate
+                echo "Cleaning up $ansible_dir"
+                rm -rf $ansible_dir/$repo
+                rm -rf $ansible_dir/python-venv
+                rmdir $ansible_dir
+              }
+              echo "stig_rhel6_ansible $ami_tag start" | logger -p local3.info -t ami-component
+              run_ansible 2>&1 | logger -p local3.info -t ami-component -s 2>&1
+              echo "stig_rhel6_ansible $ami_tag end" | logger -p local3.info -t ami-component

--- a/commonimages/base/rhel_6_10/locals.tf
+++ b/commonimages/base/rhel_6_10/locals.tf
@@ -18,8 +18,7 @@ locals {
         value = join("_", [var.ami_name_prefix, var.ami_base_name])
         }, {
         name  = "Branch"
-        value = "nomis/DSOS-1613/ami-ansible-tweaks"
-        # value = "main"   # replace main with corresponding ansible branch if you are testing
+        value = "main" # replace main with corresponding ansible branch if you are testing
       }]
     }
   ]

--- a/commonimages/base/rhel_6_10/locals.tf
+++ b/commonimages/base/rhel_6_10/locals.tf
@@ -7,25 +7,19 @@ locals {
 
   components_common = [
     {
-      name    = "yum_packages"
-      version = "0.0.1"
-      parameters = [{
-        name  = "Packages"
-        value = "wget curl unzip git nc ca-certificates gcc screen zlib-devel bzip2-devel openssl-devel ncurses-devel sqlite-devel readline-devel tk-devel gdbm-devel db4-devel xz-devel expat-devel musl-devel libffi-devel xz"
-      }]
-      }, {
       name       = "python_3_6"
-      version    = "0.0.1"
+      version    = "0.0.4"
       parameters = []
       }, {
       name    = "ansible"
-      version = "0.0.2"
+      version = "0.0.5"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])
         }, {
         name  = "Branch"
-        value = var.BRANCH_NAME == "" ? "main" : var.BRANCH_NAME
+        value = "nomis/DSOS-1613/ami-ansible-tweaks"
+        # value = "main"   # replace main with corresponding ansible branch if you are testing
       }]
     }
   ]

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -2,7 +2,7 @@
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
 
-configuration_version = "0.0.5"
+configuration_version = "0.0.6"
 description           = "shared rhel 6.10 base image"
 
 ami_base_name = "rhel_6_10"

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -2,7 +2,7 @@
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
 
-configuration_version = "0.0.2"
+configuration_version = "0.0.5"
 description           = "shared rhel 6.10 base image"
 
 ami_base_name = "rhel_6_10"

--- a/commonimages/base/rhel_7_9/locals.tf
+++ b/commonimages/base/rhel_7_9/locals.tf
@@ -14,8 +14,7 @@ locals {
         value = join("_", [var.ami_name_prefix, var.ami_base_name])
         }, {
         name  = "Branch"
-        value = "nomis/DSOS-1613/ami-ansible-tweaks"
-        # value = "main"   # replace main with corresponding ansible branch if you are testing
+        value = "main" # replace main with corresponding ansible branch if you are testing
       }]
     }
   ]

--- a/commonimages/base/rhel_7_9/locals.tf
+++ b/commonimages/base/rhel_7_9/locals.tf
@@ -3,25 +3,19 @@ locals {
 
   components_common = [
     {
-      name    = "yum_packages"
-      version = "0.0.1"
-      parameters = [{
-        name  = "Packages"
-        value = "wget curl unzip git nc ca-certificates gcc screen zlib-devel bzip2-devel openssl-devel libffi-devel"
-      }]
-      }, {
       name       = "python_3_9"
-      version    = "0.0.1"
+      version    = "0.0.3"
       parameters = []
       }, {
       name    = "ansible"
-      version = "0.0.2"
+      version = "0.0.5"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])
         }, {
         name  = "Branch"
-        value = var.BRANCH_NAME == "" ? "main" : var.BRANCH_NAME
+        value = "nomis/DSOS-1613/ami-ansible-tweaks"
+        # value = "main"   # replace main with corresponding ansible branch if you are testing
       }]
     }
   ]

--- a/commonimages/base/rhel_7_9/terraform.tfvars
+++ b/commonimages/base/rhel_7_9/terraform.tfvars
@@ -1,7 +1,7 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.0.5"
+configuration_version = "0.0.6"
 description           = "shared rhel 7.9 base image"
 
 ami_base_name = "rhel_7_9"

--- a/commonimages/base/rhel_7_9/terraform.tfvars
+++ b/commonimages/base/rhel_7_9/terraform.tfvars
@@ -1,7 +1,7 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.0.3"
+configuration_version = "0.0.5"
 description           = "shared rhel 7.9 base image"
 
 ami_base_name = "rhel_7_9"

--- a/commonimages/components/templates/ansible.yml
+++ b/commonimages/components/templates/ansible.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.3
+      default: 0.0.5
       description: "Component version, increment if you make changes."
   - Platform:
       type: string
@@ -20,7 +20,7 @@ parameters:
       description: Git branch to use when cloning the ansible repo
   - AnsibleRepo:
       type: string
-      default: modernisation-platform-ami-builds
+      default: modernisation-platform-configuration-management
       description: The ansible github repo to clone
   - AnsibleRepoDir:
       type: string
@@ -45,17 +45,22 @@ phases:
             - |
               # do not set -u as it breaks on RedHat 6
               set -e
+              PATH=$PATH:/usr/local/bin
               run_ansible() {
+                # define all params here to make standalone testing of script easier
                 repo="{{ AnsibleRepo }}"
                 ami_tag="{{ Ami }}"
                 ansible_repo_dir="{{ AnsibleRepoDir }}"
                 ansible_tags="{{ AnsibleTags }}"
+                ansible_args="{{ AnsibleArgs }}"
+                branch="{{ Branch }}"
 
                 # clone ansible roles and playbook
+                yum install -y git
                 ansible_dir=$(mktemp -d)
-                echo "Cloning $repo into $ansible_dir using branch={{ Branch }}"
+                echo "Cloning $repo into $ansible_dir using branch=$branch"
                 cd $ansible_dir
-                git clone -b {{ Branch }} "https://github.com/ministryofjustice/$repo.git"
+                git clone -b $branch "https://github.com/ministryofjustice/$repo.git"
 
                 # set python version
                 if [[ $(which python3.9 2> /dev/null) ]]; then
@@ -101,7 +106,7 @@ phases:
                 --extra-vars "target=localhost" \
                 --extra-vars "@group_vars/ami_$ami_tag.yml" \
                 --tags "$ansible_tags" \
-                --become {{ AnsibleArgs }}
+                --become $ansible_args
 
                 # Cleanup
                 deactivate
@@ -110,6 +115,6 @@ phases:
                 rm -rf $ansible_dir/python-venv
                 rmdir $ansible_dir
               }
-              echo "ansible {{ Ami }} start" | logger -p local3.info -t ami-component
-              run_ansible 2>&1 | logger -p local3.info -t ami-component
-              echo "ansible {{ Ami }} end" | logger -p local3.info -t ami-component
+              echo "ansible $ami_tag start" | logger -p local3.info -t ami-component
+              run_ansible 2>&1 | logger -p local3.info -t ami-component -s 2>&1
+              echo "ansible $ami_tag end" | logger -p local3.info -t ami-component

--- a/commonimages/components/templates/python_3_6.yml
+++ b/commonimages/components/templates/python_3_6.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.2
+      default: 0.0.4
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -20,28 +20,47 @@ phases:
           commands:
             - |
               set -e
-              cd /tmp
-              py_version=3.6.3
-              py_file=Python-$py_version
-              py_tar=$py_file.tar.xz
-              # download and build Python
-              wget --no-check-certificate https://python.org/ftp/python/$py_version/$py_tar
-              tar xf $py_tar
-              rm -f $py_tar
-              cd $py_file/
-              # ensure zlib is enabled, required for some ansible modules
-              sed -i 's/^#zlib/zlib/' Modules/Setup.dist
-              ./configure --enable-optimizations
-              sudo make altinstall
+              PATH=$PATH:/usr/local/bin
+              main() {
+                cd /tmp
+                # install packages to build python
+                yum install -y gcc wget ca-certificates
+                # install packages for python extenions
+                yum install -y openssl-devel zlib-devel bzip2-devel ncurses-devel sqlite-devel readline-devel tk-devel
+                yum install -y gdbm-devel db4-devel xz-devel expat-devel
+
+                py_version=3.6.3
+                py_file=Python-$py_version
+                py_tar=$py_file.tar.xz
+                # download and build Python
+                wget --no-check-certificate https://python.org/ftp/python/$py_version/$py_tar
+                tar xf $py_tar
+                rm -f $py_tar
+                cd $py_file/
+                # ensure zlib is enabled, required for some ansible modules
+                sed -i 's/^#zlib/zlib/' Modules/Setup.dist
+                ./configure --enable-optimizations
+                sudo make altinstall
+              }
+              echo "python3.6 start" | logger -p local3.info -t ami-component
+              main 2>&1 | logger -p local3.info -t ami-component -s 2>&1
+              echo "python3.6 end" | logger -p local3.info -t ami-component
+
       - name: InstallPipAndVirtualenv
         action: ExecuteBash
         inputs:
           commands:
             - |
               set -e
-              cd /tmp
-              # install pip and virtualenv
-              wget https://bootstrap.pypa.io/pip/3.6/get-pip.py
-              python3.6 get-pip.py
-              python3.6 -m pip install --upgrade pip
-              python3.6 -m pip install virtualenv
+              PATH=$PATH:/usr/local/bin
+              main() {
+                cd /tmp
+                # install pip and virtualenv
+                wget https://bootstrap.pypa.io/pip/3.6/get-pip.py
+                python3.6 get-pip.py
+                python3.6 -m pip install --upgrade pip
+                python3.6 -m pip install virtualenv
+              }
+              echo "python3.6 virtualenv start" | logger -p local3.info -t ami-component
+              main 2>&1 | logger -p local3.info -t ami-component -s 2>&1
+              echo "python3.6 virtualenv end" | logger -p local3.info -t ami-component

--- a/commonimages/components/templates/python_3_9.yml
+++ b/commonimages/components/templates/python_3_9.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.1
+      default: 0.0.3
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -20,17 +20,31 @@ phases:
           commands:
             - |
               set -e
-              cd /tmp
-              py_version=3.9.6
-              # install python
-              wget https://www.python.org/ftp/python/$py_version/Python-$py_version.tgz
-              tar xzf Python-$py_version.tgz
-              rm -f Python-$py_version.tgz
-              cd Python-$py_version
-              # ensure zlib is enabled, required for some ansible modules
-              sed -i 's/^#zlib/zlib/' Modules/Setup
-              ./configure --enable-optimizations
-              sudo make altinstall
+              PATH=$PATH:/usr/local/bin
+              main() {
+                export PIP_ROOT_USER_ACTION=ignore
+                cd /tmp
+                # install packages to build python
+                yum install -y gcc wget ca-certificates libffi-devel
+                # install packages for python extenions
+                yum install -y openssl-devel zlib-devel bzip2-devel ncurses-devel sqlite-devel readline-devel tk-devel
+                yum install -y gdbm-devel db4-devel xz-devel expat-devel
+
+                py_version=3.9.6
+                # install python
+                wget https://www.python.org/ftp/python/$py_version/Python-$py_version.tgz
+                tar xzf Python-$py_version.tgz
+                rm -f Python-$py_version.tgz
+                cd Python-$py_version
+                # ensure zlib is enabled, required for some ansible modules
+                sed -i 's/^#zlib/zlib/' Modules/Setup
+                ./configure --enable-optimizations
+                sudo make altinstall
+              }
+              echo "python3.9 start" | logger -p local3.info -t ami-component
+              main 2>&1 | logger -p local3.info -t ami-component -s 2>&1
+              echo "python3.9 end" | logger -p local3.info -t ami-component
+
       # Install pip
       - name: InstallPipAndVirtualenv
         action: ExecuteBash
@@ -38,6 +52,13 @@ phases:
           commands:
             - |
               set -e
-              # install pip and virtualenv
-              python3.9 -m pip install --upgrade pip
-              python3.9 -m pip install virtualenv
+              PATH=$PATH:/usr/local/bin
+              main() {
+                export PIP_ROOT_USER_ACTION=ignore
+                # install pip and virtualenv
+                python3.9 -m pip install --upgrade pip
+                python3.9 -m pip install virtualenv
+              }
+              echo "python3.9 virtualenv start" | logger -p local3.info -t ami-component
+              main 2>&1 | logger -p local3.info -t ami-component -s 2>&1
+              echo "python3.9 virtualenv end" | logger -p local3.info -t ami-component


### PR DESCRIPTION
Some minor enhancements to the RHEL base images:
- ensure component logs (python, ansible, stig) are available in both syslog and cloudwatch
- ansible and python components are no longer dependent on the packages component, e.g. python component installs all the packages it needs to build python. 
- using the modernisation-platform-configuration-management for the ansible code
- no longer installing node-exporter in base AMI