### PR TITLE
add enable-psremoting on install of powershell-core

### DIFF
--- a/teams/nomis/components/windows_server_2022_jumpserver/powershell_core.yml
+++ b/teams/nomis/components/windows_server_2022_jumpserver/powershell_core.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.1.3
+      default: 0.1.4
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -13,7 +13,7 @@ parameters:
       description: Platform.
   - PowerShellCoreVersion:
       type: string
-      default: 7.3.0
+      default: 7.3.1
       description: Version of the PowerShell Core to install
 phases:
   - name: build
@@ -25,5 +25,5 @@ phases:
             - |
               choco install -y chocolatey-core.extension
               choco install -y kb3118401
-              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 REGISTER_MANIFEST=1 ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL=1"'
+              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 REGISTER_MANIFEST=1 ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL=1 ENABLE_PSREMOTING=1"'
               Set-ItemProperty -Path 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\WinLogon' -Name Shell -Value 'C:\Program Files\Powershell\7\pwsh.exe' -ErrorAction Stop

--- a/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
+++ b/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "windows_server_2022_jumpserver"
-configuration_version = "0.3.2"
+configuration_version = "0.3.3"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2022 jumpserver"
 


### PR DESCRIPTION
This _may_ address the jumpserver issue for RDP getting Pwsh Core 7.3.1 installed and remoting enabled. At the moment you open in a pwsh core window and not a full desktop GUI session, possibly because pwsh core is being set as the default shell. 

If this doesn't work I'll revert the "set as default shell" step and retest it again