### PR TITLE
revert setting powershell core as the default shell

### DIFF
--- a/teams/nomis/components/windows_server_2022_jumpserver/powershell_core.yml
+++ b/teams/nomis/components/windows_server_2022_jumpserver/powershell_core.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.1.4
+      default: 0.1.5
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -26,4 +26,3 @@ phases:
               choco install -y chocolatey-core.extension
               choco install -y kb3118401
               choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 REGISTER_MANIFEST=1 ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL=1 ENABLE_PSREMOTING=1"'
-              Set-ItemProperty -Path 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\WinLogon' -Name Shell -Value 'C:\Program Files\Powershell\7\pwsh.exe' -ErrorAction Stop

--- a/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
+++ b/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "windows_server_2022_jumpserver"
-configuration_version = "0.3.3"
+configuration_version = "0.3.4"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2022 jumpserver"
 


### PR DESCRIPTION
this appears to break the normal RDP process where a desktop is available

mistakenly set the "on-login" value in the registry to present a powershell windows as if this was windows-server-core rather than allowing the full desktop experience