### PR TITLE
Allow access to new core-shared-services artefact bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .terragrunt-cache
 *.tfstate*
 .DS_Store
+.idea/
 tmp/
 .vscode/
 .terraform.lock.hcl

--- a/modernisation-platform/iam.tf
+++ b/modernisation-platform/iam.tf
@@ -46,6 +46,8 @@ resource "aws_iam_role" "image_builder_role" {
             Resource = [
               "arn:aws:s3:::ec2-image-builder-*/*",
               "arn:aws:s3:::ec2-image-builder-*",
+              "arn:aws:s3:::mod-platform-image-artefact-bucket*/*",
+              "arn:aws:s3:::mod-platform-image-artefact-bucket*"
             ]
           },
           {


### PR DESCRIPTION
A new artefact bucket was created in the `core-shared-services` account as part of [this customer request](https://github.com/ministryofjustice/modernisation-platform/issues/2922), however the IAM policy allowing access to this bucket was not updated.

This PR should resolve that.