### PR TITLE
Adding a new pipeline as an example and test of operations against the artefact s3 bucket

### DIFF
--- a/teams/example/components/windows/s3_operations.yml
+++ b/teams/example/components/windows/s3_operations.yml
@@ -1,0 +1,38 @@
+---
+name: S3 operations on Windows example
+description: Upload/download objects from/to Windows to/from S3.
+schemaVersion: 1.0
+parameters:
+  - Version:
+      type: string
+      description: Component version (update this each time the file changes). Set outside of this document (in the pipeline variables).
+  - Platform:
+      type: string
+      default: "Windows"
+      description: Platform.
+  - S3bucket:
+      type: string
+      description: Name of the S3 bucket to upload/download to/from. Set outside of this document (in the pipeline variables).
+  - Key:
+      type: string
+      description: Path to the file on the S3 bucket. Set outside of this document (in the pipeline variables).
+  - FilePath:
+      type: string
+      description: Path to the file on the EC2. Set outside of this document (in the pipeline variables).
+phases:
+  - name: build
+    steps:
+      - name: push_to_s3
+        action: ExecutePowerShell
+        inputs:
+          commands:
+            - |
+              Write-S3Object -BucketName {{ S3bucket }} -Key {{ Key }} -Content "Hello World"
+  - name: test
+    steps:
+      - name: download_from_s3
+        action: ExecutePowerShell
+        inputs:
+          commands:
+            - |
+              Read-S3Object -BucketName {{ S3bucket }} -Key {{ Key }} -File {{ FilePath }}

--- a/teams/example/windows_s3_test_pipeline.tf
+++ b/teams/example/windows_s3_test_pipeline.tf
@@ -1,0 +1,119 @@
+resource "aws_imagebuilder_image_pipeline" "windows_s3_test" {
+  image_recipe_arn                 = aws_imagebuilder_image_recipe.windows_s3_test.arn
+  infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.windows_s3_test.arn
+  distribution_configuration_arn   = aws_imagebuilder_distribution_configuration.windows_s3_test.arn
+  name                             = local.windows_s3_test.pipeline.name
+
+  schedule {
+    schedule_expression                = local.windows_s3_test.pipeline.schedule
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE"
+  }
+
+}
+
+
+/* This is being commented for reference, it is not necessary to deploy this and it takes a long time to apply.
+resource "aws_imagebuilder_image" "windows_s3_test" {
+  distribution_configuration_arn   = aws_imagebuilder_distribution_configuration.windows_s3_test.arn
+  image_recipe_arn                 = aws_imagebuilder_image_recipe.windows_s3_test.arn
+  infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.windows_s3_test.arn
+}
+*/
+
+
+resource "aws_imagebuilder_image_recipe" "windows_s3_test" {
+  block_device_mapping {
+    device_name = local.windows_s3_test.recipe.device_name
+
+    ebs {
+      delete_on_termination = local.windows_s3_test.recipe.ebs.delete_on_termination
+      volume_size           = local.windows_s3_test.recipe.ebs.volume_size
+      volume_type           = local.windows_s3_test.recipe.ebs.volume_type
+      encrypted             = local.windows_s3_test.recipe.ebs.encrypted
+      kms_key_id            = data.aws_kms_key.ebs_encryption_cmk.arn
+    }
+  }
+
+  dynamic "component" {
+    for_each = toset(local.windows_s3_test.components)
+    content {
+      component_arn = aws_imagebuilder_component.windows_s3_test_components[component.value.document].arn
+      dynamic "parameter" {
+        for_each = { for param_key, param_value in component.value.parameters : param_key => param_value if component.value.parameters != {} }
+        content {
+          name  = parameter.key
+          value = parameter.value
+        }
+      }
+    }
+  }
+
+  dynamic "component" {
+    for_each = toset(local.windows_s3_test.aws_components)
+    content {
+      component_arn = "arn:aws:imagebuilder:eu-west-2:aws:component/${component.key}/x.x.x"
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  name         = local.windows_s3_test.recipe.name
+  parent_image = local.windows_s3_test.recipe.parent_image
+  version      = local.windows_s3_test.recipe.version
+}
+
+
+resource "aws_imagebuilder_infrastructure_configuration" "windows_s3_test" {
+  description                   = local.windows_s3_test.infra_config.description
+  instance_profile_name         = data.terraform_remote_state.mp-imagebuilder.outputs.image_builder_profile
+  instance_types                = local.windows_s3_test.infra_config.instance_types
+  name                          = local.windows_s3_test.infra_config.name
+  security_group_ids            = local.windows_s3_test.infra_config.security_group_ids
+  subnet_id                     = local.windows_s3_test.infra_config.subnet_id
+  terminate_instance_on_failure = local.windows_s3_test.infra_config.terminate_on_fail
+
+  logging {
+    s3_logs {
+      s3_bucket_name = data.terraform_remote_state.modernisation-platform-repo.outputs.imagebuilder_log_bucket_id
+      s3_key_prefix  = "mp"
+    }
+  }
+}
+
+// create each component in team directory
+resource "aws_imagebuilder_component" "windows_s3_test_components" {
+  for_each = { for component in local.windows_s3_test.components : component.document => component.parameters }
+
+  data     = file("components/windows/${each.key}")
+  name     = join("_", ["example", trimsuffix(each.key, ".yml")])
+  platform = yamldecode(file("components/windows/${each.key}")).parameters[1].Platform.default
+  version  = each.value.Version
+
+  kms_key_id = data.aws_kms_key.ebs_encryption_cmk.arn
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+
+
+resource "aws_imagebuilder_distribution_configuration" "windows_s3_test" {
+  name = local.windows_s3_test.distribution.name
+
+  distribution {
+    region = local.windows_s3_test.distribution.region
+
+    ami_distribution_configuration {
+
+      name       = local.windows_s3_test.distribution.ami_name
+      kms_key_id = data.aws_kms_key.ebs_encryption_cmk.arn
+
+      launch_permission {
+        user_ids = local.ami_share_accounts
+      }
+    }
+  }
+}

--- a/teams/example/windows_s3_test_pipeline_vars.tf
+++ b/teams/example/windows_s3_test_pipeline_vars.tf
@@ -1,0 +1,63 @@
+locals {
+
+  # Recipe's version:
+  windows_s3_test_recipe_version = "1.0.0"
+
+  # Component's version:
+  s3_operations_component_version = "1.0.0"
+
+  windows_s3_test = {
+
+    pipeline = {
+      name     = join("", [local.team_name, "_WindowsServer2022_s3_test"])
+      schedule = "cron(0 0 2 * ? *)" # day after source image is built
+    }
+
+    recipe = {
+      name         = join("", [local.team_name, "_WindowsServer2022_s3_test"])
+      parent_image = "arn:aws:imagebuilder:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:image/mp-windowsserver2022/x.x.x"
+      version      = local.windows_s3_test_recipe_version
+      device_name  = "/dev/sda1"
+
+      ebs = {
+        delete_on_termination = true
+        volume_size           = 30
+        volume_type           = "gp2"
+        encrypted             = true
+      }
+    }
+
+    infra_config = {
+      description        = "Description here"
+      instance_types     = ["t3.medium"]
+      name               = join("", [local.team_name, "_WindowsServer2022_s3_test"])
+      security_group_ids = [data.terraform_remote_state.modernisation-platform-repo.outputs.image_builder_security_group_id]
+      subnet_id          = data.terraform_remote_state.modernisation-platform-repo.outputs.non_live_private_subnet_ids[0]
+      terminate_on_fail  = true
+    }
+
+    distribution = {
+      name     = join("", [local.team_name, "_WindowsServer2022_s3_test"])
+      region   = "eu-west-2"
+      ami_name = join("", [local.team_name, "_WindowsServer2022_s3_test_{{ imagebuilder:buildDate }}"])
+    }
+
+    components = [
+      {
+        document = "s3_operations.yml",
+        parameters = {
+          Version  = local.s3_operations_component_version,
+          S3bucket = "mod-platform-image-artefact-bucket20230203091453221500000001" //TODO S3 bucket name could be retrieved from data.terraform_remote_state.modernisation-platform-repo if the bucket name output was specified
+          Key      = "example-${local.team_name}/test"
+          FilePath = "C:\\Windows\\TEMP\\test"
+        }
+      }
+    ]
+
+    # Removed "stig-build-windows-medium" because current version 1.5.1 does not support the Parent Image OS Version of Microsoft Windows Server 2022
+    # For more info refer to https://docs.aws.amazon.com/imagebuilder/latest/userguide/toe-stig.html
+    # Not needed for this example, as the base AMI is the MP AMI with some software already installed.
+    aws_components = []
+
+  }
+}


### PR DESCRIPTION
This PR should help with debugging issues with the artefact s3 bucket permissions like in this thread: https://mojdt.slack.com/archives/C01A7QK5VM1/p1675936798843929

It is tricky to test it, without building a pipeline itself (accessing s3 bucket from an EC2 image builder), so since it's been done once, keeping it in code here.