### PR TITLE
DSOS-1761: glob for x86, to avoid the arm64 image

### DIFF
--- a/commonimages/base/rhel_8_5/terraform.tfvars
+++ b/commonimages/base/rhel_8_5/terraform.tfvars
@@ -14,7 +14,7 @@ tags = {
 parent_image = {
   owner = "309956199498" # Redhat
   ami_search_filters = {
-    name = ["RHEL-8.5_HVM-*"]
+    name = ["RHEL-8.5_HVM-*x86*"]
   }
 }
 


### PR DESCRIPTION
Avoid the arm64 image, to match our EC2 architecture