### PR TITLE
DSOS-1836: allow access to buckets named -software

### DIFF
--- a/modernisation-platform/iam.tf
+++ b/modernisation-platform/iam.tf
@@ -46,6 +46,8 @@ resource "aws_iam_role" "image_builder_role" {
             Resource = [
               "arn:aws:s3:::ec2-image-builder-*/*",
               "arn:aws:s3:::ec2-image-builder-*",
+              "arn:aws:s3:::*-software*/*",
+              "arn:aws:s3:::*-software*",
               "arn:aws:s3:::mod-platform-image-artefact-bucket*/*",
               "arn:aws:s3:::mod-platform-image-artefact-bucket*",
               "arn:aws:s3:::modernisation-platform-software*/*",

--- a/modernisation-platform/iam.tf
+++ b/modernisation-platform/iam.tf
@@ -120,6 +120,32 @@ resource "aws_iam_role" "image_builder_role" {
       }
     )
   }
+  inline_policy {
+    name = "ImageBuilderKmsPolicy"
+    policy = jsonencode(
+      {
+        Statement = [
+          {
+            Action = [
+              "kms:Encrypt",
+              "kms:Decrypt",
+              "kms:ReEncrypt*",
+              "kms:GenerateDataKey*",
+              "kms:DescribeKey",
+              "kms:CreateGrant",
+              "kms:ListGrants",
+              "kms:RevokeGrant",
+            ]
+            Effect = "Allow"
+            Resource = [
+              "arn:aws:kms:eu-west-2:*:key/*"
+            ]
+          },
+        ]
+        Version = "2012-10-17"
+      }
+    )
+  }
 
   tags     = {}
   tags_all = {}


### PR DESCRIPTION
In our new nomis-x-test accounts (x being data-hub or combined-reporting), we've created a nomis-x-software s3 bucket.
This is for both image builder and all 4 accounts within the application.   Probably should have called it ec2-image-builder-xyz in hindsight but it's a bit late now, plus it's not exclusively for image-builder.
Is it possible to add to the policy to allow image builder to access these buckets?

In addition, added access to cmk kms keys.  The business unit keys weren't available, but I guess it's possible image builder users might share other keys also so just wildcarded it.  Hope this is OK.