### PR TITLE
Install openssl + dependencies as part of IAPS ami build 

### DIFF
--- a/teams/delius-iaps/components/iaps_server/delius_iaps_install_base_packages.yml
+++ b/teams/delius-iaps/components/iaps_server/delius_iaps_install_base_packages.yml
@@ -27,8 +27,8 @@ phases:
               Write-Host('vcredist packages')
               # choco install -y vcredist2010 # Commented out - hoping we don't need to explicitly mention this due to dynamic package dependency
               # choco install -y vcredist2008 # Commented out - hoping we don't need to explicitly mention this due to dynamic package dependency
-              cinst -y vcredist140
-              cinst -y vcredist2015
+              choco install -y vcredist140
+              choco install -y vcredist2015
 
               Write-Host('nginx proxy')
               choco install -y nginx

--- a/teams/delius-iaps/components/iaps_server/delius_iaps_install_base_packages.yml
+++ b/teams/delius-iaps/components/iaps_server/delius_iaps_install_base_packages.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.1.4
+      default: 0.1.5
       description: Component version
   - Platform:
       type: string
@@ -27,6 +27,8 @@ phases:
               Write-Host('vcredist packages')
               # choco install -y vcredist2010 # Commented out - hoping we don't need to explicitly mention this due to dynamic package dependency
               # choco install -y vcredist2008 # Commented out - hoping we don't need to explicitly mention this due to dynamic package dependency
+              cinst -y vcredist140
+              cinst -y vcredist2015
 
               Write-Host('nginx proxy')
               choco install -y nginx
@@ -39,3 +41,6 @@ phases:
 
               Write-Host('OpenSSL util')
               choco install -y openssl # install latest version
+
+              # Move OpenSSL to a location that is in the PATH
+              move /Y "C:\Program Files\OpenSSL-Win64\bin\openssl.exe" "C:\ProgramData\chocolatey\bin"

--- a/teams/delius-iaps/iaps_server/terraform.tfvars
+++ b/teams/delius-iaps/iaps_server/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "delius"
 ami_base_name         = "iaps_server"
-configuration_version = "0.0.22"
+configuration_version = "0.0.23"
 release_or_patch      = "patch" # see nomis AMI image building strategy doc
 description           = "Delius IAPS server"
 


### PR DESCRIPTION
install openssl dependencies explicitely as part of build.  After installing openssl, move binary to location on PATH