### PR TITLE
Updating owner for RHEL 6.10

### DIFF
--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -13,7 +13,7 @@ tags = {
 }
 
 parent_image = {
-  owner = "309956199498" # Redhat
+  owner = "679593333241" # Redhat
   ami_search_filters = {
     name = ["RHEL-6.10_HVM-*"]
   }


### PR DESCRIPTION
Owner **309956199498** does not exist for AMI **RHEL-6.10_HVM-\***.