### PR TITLE
NIT-625 fix firefox install step

### DIFF
--- a/teams/delius-iaps/components/iaps_server/delius_iaps_install_base_packages.yml
+++ b/teams/delius-iaps/components/iaps_server/delius_iaps_install_base_packages.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.1.9
+      default: 0.1.10
       description: Component version
   - Platform:
       type: string
@@ -14,6 +14,21 @@ parameters:
 phases:
   - name: build
     steps:
+      # Download cert file using the ActionModule, as it provides the option to ignore cert validation errors. See commit message for more details
+      - name: DownloadLetsEncryptRootCert
+        action: WebDownload
+        onFailure: Abort
+        inputs:
+          - source: https://letsencrypt.org/certs/isrgrootx1.der
+            destination: C:\Windows\Temp\certs\isrgrootx1.der
+            ignoreCertificateErrors: true
+      # Install Let's Encrypt root CA. See commit message for more details
+      - name: ImportLetsEncryptRootCert
+        action: ExecutePowerShell
+        onFailure: Abort
+        inputs:
+          commands:
+            - Import-Certificate -FilePath C:\Windows\Temp\certs\isrgrootx1.der -CertStoreLocation Cert:\LocalMachine\Root
       - name: DeliusIapsInstallBasePackages
         action: ExecutePowerShell
         inputs:
@@ -45,7 +60,7 @@ phases:
               choco install -y nginx
 
               Write-Host('Firefox browser')
-              choco install -y firefox # install latest version
+              choco install -y firefoxesr --params "/l:en-GB" # install latest long-term support version
 
               Write-Host('7Zip archive util')
               choco install -y 7zip # install latest version

--- a/teams/delius-iaps/iaps_server/terraform.tfvars
+++ b/teams/delius-iaps/iaps_server/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "delius"
 ami_base_name         = "iaps_server"
-configuration_version = "0.0.28"
+configuration_version = "0.0.29"
 
 release_or_patch = "patch" # see nomis AMI image building strategy doc
 description      = "Delius IAPS server"


### PR DESCRIPTION
Windows downloads new root certificates using Windows Update, which we can't run easily from MP. Mozilla uses Let's Encrypt certificates. The current root CA cert of Let's Encrypt is not in the Windows cert store by default.

We download it manually through an Image Builder function, as native PowerShell methods fail to download due to lack of trust. Additionally -SkipCertificateCheck is not available in the version of PowerShell we are currently running

Useful links:
https://letsencrypt.org/certificates/
https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/ https://www.stephenwagner.com/2021/09/30/sophos-dst-root-ca-x3-expiration-problems-fix/