### PR TITLE
Nomis/dsos 1865/windows jumpserver prerequisites

### DIFF
--- a/commonimages/components/templates/aws_cli.yml
+++ b/commonimages/components/templates/aws_cli.yml
@@ -1,0 +1,25 @@
+---
+name: aws_cli
+description: Component to Install the AWS Cli on Windows
+schemaVersion: 1.0
+parameters:
+  - Version:
+      type: string
+      default: 0.0.1
+      description: Component version (update this each time the file changes)
+  - Platform:
+      type: string
+      default: "Windows"
+      description: Platform.
+  - AwsCliVersion:
+      type: string
+      default: 2.11.13
+      description: Version of the AWS Cli to install
+phases:
+  - name: build
+    steps:
+      - name: InstallAwsCli
+        action: ExecutePowerShell
+        inputs:
+          commands:
+            - choco install -y awscli --version '{{ AwsCliVersion }}'

--- a/commonimages/components/templates/powershell_core.yml
+++ b/commonimages/components/templates/powershell_core.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.1.9
+      default: 0.2.0
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -13,7 +13,7 @@ parameters:
       description: Platform.
   - PowerShellCoreVersion:
       type: string
-      default: 7.3.1
+      default: 7.3.4
       description: Version of the PowerShell Core to install
 phases:
   - name: build

--- a/teams/nomis/components/windows_server_2019_jumpserver/jumpserver_2019.yml
+++ b/teams/nomis/components/windows_server_2019_jumpserver/jumpserver_2019.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 1.0.0
+      default: 1.0.1
       description: Component version (update this each time the file changes)
   - Platform:
       type: string

--- a/teams/nomis/components/windows_server_2019_jumpserver/jumpserver_2019.yml
+++ b/teams/nomis/components/windows_server_2019_jumpserver/jumpserver_2019.yml
@@ -74,7 +74,7 @@ phases:
 
               # Download SQL Developer
               Read-S3Object -BucketName $S3_BUCKET -Key jumpserver-software/sqldeveloper-22.2.1.234.1810-x64.zip -File C:\jumpserver-software\sqldeveloper-22.2.1.234.1810-x64.zip
-              
+
               # Extract SQL Developer - there is no installer for this application
               Expand-Archive -Path C:\jumpserver-software\sqldeveloper-22.2.1.234.1810-x64.zip -DestinationPath "C:\Program Files\Oracle"
 

--- a/teams/nomis/components/windows_server_2019_jumpserver/jumpserver_2019.yml
+++ b/teams/nomis/components/windows_server_2019_jumpserver/jumpserver_2019.yml
@@ -65,3 +65,21 @@ phases:
               $reg_path = "HKLM:\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings"
               New-Item -Path $reg_path -Force
               New-ItemProperty -Path $reg_path -Name Security_HKLM_only -Value 1 -PropertyType DWORD -Force
+      - name: ConfigureSQLDeveloper
+        action: ExecutePowerShell
+        inputs:
+          commands:
+            - |
+              $S3_BUCKET = "ec2-image-builder-nomis20220314103938567000000001"
+
+              # Download SQL Developer
+              Read-S3Object -BucketName $S3_BUCKET -Key jumpserver-software/sqldeveloper-22.2.1.234.1810-x64.zip -File C:\jumpserver-software\sqldeveloper-22.2.1.234.1810-x64.zip
+              
+              # Extract SQL Developer - there is no installer for this application
+              Expand-Archive -Path C:\jumpserver-software\sqldeveloper-22.2.1.234.1810-x64.zip -DestinationPath "C:\Program Files\Oracle"
+
+              # Create a desktop shortcut
+              $shortcut = New-Object -ComObject WScript.Shell
+              $shortcut_link = $shortcut.CreateShortcut("C:\Users\Public\Desktop\SQL Developer.lnk")
+              $shortcut_link.TargetPath = "C:\Program Files\Oracle\sqldeveloper\sqldeveloper.exe"
+              $shortcut_link.Save()

--- a/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
+++ b/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
@@ -65,3 +65,24 @@ phases:
               $reg_path = "HKLM:\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings"
               New-Item -Path $reg_path -Force
               New-ItemProperty -Path $reg_path -Name Security_HKLM_only -Value 1 -PropertyType DWORD -Force
+      - name: ConfigureSQLDeveloper
+        action: ExecutePowerShell
+        inputs:
+          commands:
+            - |
+              $S3_BUCKET = "ec2-image-builder-nomis20220314103938567000000001"
+
+              # Download SQL Developer
+              Read-S3Object -BucketName $S3_BUCKET -Key jumpserver-software/sqldeveloper-22.2.1.234.1810-x64.zip -File C:\jumpserver-software\sqldeveloper-22.2.1.234.1810-x64.zip
+
+              # Extract SQL Developer - there is no installer for this application
+              Expand-Archive -Path C:\jumpserver-software\sqldeveloper-22.2.1.234.1810-x64.zip -DestinationPath "C:\Program Files\Oracle"
+
+              # Create a desktop shortcut
+              $shortcut = New-Object -ComObject WScript.Shell
+              $shortcut_link = $shortcut.CreateShortcut("C:\Users\Public\Desktop\SQL Developer.lnk")
+              $shortcut_link.TargetPath = "C:\Program Files\Oracle\sqldeveloper\sqldeveloper.exe"
+              $shortcut_link.Save()
+
+
+

--- a/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
+++ b/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 1.0.13
+      default: 1.0.14
       description: Component version (update this each time the file changes)
   - Platform:
       type: string

--- a/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
+++ b/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
@@ -83,6 +83,3 @@ phases:
               $shortcut_link = $shortcut.CreateShortcut("C:\Users\Public\Desktop\SQL Developer.lnk")
               $shortcut_link.TargetPath = "C:\Program Files\Oracle\sqldeveloper\sqldeveloper.exe"
               $shortcut_link.Save()
-
-
-

--- a/teams/nomis/windows_server_2019_jumpserver/locals.tf
+++ b/teams/nomis/windows_server_2019_jumpserver/locals.tf
@@ -1,13 +1,13 @@
 locals {
   components_common = [
     {
-      name       = "prometheus_windows_exporter"
-      version    = "1.1.7"
+      name       = "powershell_core"
+      version    = "0.2.0"
       parameters = []
     },
     {
-      name       = "powershell_core"
-      version    = "0.1.9"
+      name       = "aws_cli"
+      version    = "0.0.1"
       parameters = []
     },
   ]

--- a/teams/nomis/windows_server_2019_jumpserver/terraform.tfvars
+++ b/teams/nomis/windows_server_2019_jumpserver/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "windows_server_2019_jumpserver"
-configuration_version = "0.0.2"
+configuration_version = "0.0.3"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2019 jumpserver"
 

--- a/teams/nomis/windows_server_2019_jumpserver/terraform.tfvars
+++ b/teams/nomis/windows_server_2019_jumpserver/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "windows_server_2019_jumpserver"
-configuration_version = "0.0.1"
+configuration_version = "0.0.2"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2019 jumpserver"
 

--- a/teams/nomis/windows_server_2022_jumpserver/locals.tf
+++ b/teams/nomis/windows_server_2022_jumpserver/locals.tf
@@ -1,13 +1,13 @@
 locals {
   components_common = [
     {
-      name       = "prometheus_windows_exporter"
-      version    = "1.1.7"
+      name       = "powershell_core"
+      version    = "0.2.0"
       parameters = []
     },
     {
-      name       = "powershell_core"
-      version    = "0.1.9"
+      name       = "aws_cli"
+      version    = "0.0.1"
       parameters = []
     },
   ]

--- a/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
+++ b/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "windows_server_2022_jumpserver"
-configuration_version = "0.3.6"
+configuration_version = "0.3.7"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2022 jumpserver"
 

--- a/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
+++ b/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "windows_server_2022_jumpserver"
-configuration_version = "0.3.7"
+configuration_version = "0.3.8"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2022 jumpserver"
 


### PR DESCRIPTION
- adds aws cli to 'common' components so can be pulled into any windows version
  - uses chocolately as this allows you to easily specify a version
  - aws will now be on the PATH so ansible roles (if we use them) don't have to keep specifying this
- uprev version of pwsh to 7.3.4
- removed prometheus-windows-exporter as we're not scraping these/metrics like this anymore
- installs SQL Developer package. There's no installer as such, just copy files to "folder" and run the exe
  - put a shortcut on the desktop to make this easy to kick off