### PR TITLE
Nit 636 iaps automate sql developer config changes on instance rebuild

### DIFF
--- a/teams/delius-iaps/components/files/connections.xml
+++ b/teams/delius-iaps/components/files/connections.xml
@@ -1,0 +1,115 @@
+<?xml version = '1.0' encoding = 'UTF-8'?>
+<References xmlns="http://xmlns.oracle.com/adf/jndi">
+    <Reference name="IAPS as NPS" className="oracle.jdeveloper.db.adapter.DatabaseProvider" xmlns="">
+        <Factory className="oracle.jdevimpl.db.adapter.DatabaseProviderFactory1212"/>
+        <RefAddresses>
+            <StringRefAddr addrType="role">
+            <Contents/>
+            </StringRefAddr>
+            <StringRefAddr addrType="SavePassword">
+            <Contents>true</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="OracleConnectionType">
+            <Contents>BASIC</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="RaptorConnectionType">
+            <Contents>Oracle</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="sid">
+            <Contents>IAPS</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="customUrl">
+            <Contents>jdbc:oracle:thin:@[DB_HOST_PLACEHOLDER]:1521:IAPS</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="oraDriverType">
+            <Contents>thin</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="NoPasswordConnection">
+            <Contents>TRUE</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="hostname">
+            <Contents>[DB_HOST_PLACEHOLDER]</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="password">
+            <Contents>[NPS_DB_PWD_PLACEHOLDER]</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="driver">
+            <Contents>oracle.jdbc.OracleDriver</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="port">
+            <Contents>1521</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="subtype">
+            <Contents>oraJDBC</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="OS_AUTHENTICATION">
+            <Contents>false</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="user">
+            <Contents>nps</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="KERBEROS_AUTHENTICATION">
+            <Contents>false</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="ConnName">
+            <Contents>IAPS as NPS</Contents>
+            </StringRefAddr>
+        </RefAddresses>
+    </Reference>
+    <Reference name="IAPS as Shadow" className="oracle.jdeveloper.db.adapter.DatabaseProvider" xmlns="">
+        <Factory className="oracle.jdevimpl.db.adapter.DatabaseProviderFactory1212"/>
+        <RefAddresses>
+            <StringRefAddr addrType="role">
+            <Contents/>
+            </StringRefAddr>
+            <StringRefAddr addrType="SavePassword">
+            <Contents>true</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="OracleConnectionType">
+            <Contents>BASIC</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="RaptorConnectionType">
+            <Contents>Oracle</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="sid">
+            <Contents>IAPS</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="customUrl">
+            <Contents>jdbc:oracle:thin:@[DB_HOST_PLACEHOLDER]:1521:IAPS</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="oraDriverType">
+            <Contents>thin</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="NoPasswordConnection">
+            <Contents>TRUE</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="hostname">
+            <Contents>[DB_HOST_PLACEHOLDER]</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="password">
+            <Contents>[SHADOW_DB_PWD_PLACEHOLDER]</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="driver">
+            <Contents>oracle.jdbc.OracleDriver</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="port">
+            <Contents>1521</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="subtype">
+            <Contents>oraJDBC</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="OS_AUTHENTICATION">
+            <Contents>false</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="user">
+            <Contents>SHADOW</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="KERBEROS_AUTHENTICATION">
+            <Contents>false</Contents>
+            </StringRefAddr>
+            <StringRefAddr addrType="ConnName">
+            <Contents>IAPS as Shadow</Contents>
+            </StringRefAddr>
+        </RefAddresses>
+    </Reference>
+</References>

--- a/teams/delius-iaps/components/files/login.cmd
+++ b/teams/delius-iaps/components/files/login.cmd
@@ -1,0 +1,2 @@
+Powershell -Command "Set-ExecutionPolicy Unrestricted CurrentUser" >> "%TEMP%\StartupLog.txt" 2>&1
+Powershell C:\scripts\login.ps1 >> "%TEMP%\StartupLog.txt" 2>&1

--- a/teams/delius-iaps/components/files/login.cmd
+++ b/teams/delius-iaps/components/files/login.cmd
@@ -1,2 +1,1 @@
-Powershell -Command "Set-ExecutionPolicy Unrestricted CurrentUser" >> "%TEMP%\StartupLog.txt" 2>&1
-Powershell C:\scripts\login.ps1 >> "%TEMP%\StartupLog.txt" 2>&1
+Powershell -NoProfile -ExecutionPolicy Bypass -File "C:\scripts\login.ps1" >> "%TEMP%\LoginLog.txt" 2>&1

--- a/teams/delius-iaps/components/files/login.ps1
+++ b/teams/delius-iaps/components/files/login.ps1
@@ -1,0 +1,5 @@
+$connectionXMLDirectory = "C:\Users\$($ENV:USERNAME)\AppData\Roaming\SQL Developer\system4.1.3.20.78\o.jdeveloper.db.connection.12.2.1.0.42.151001.541"
+New-Item -ItemType Directory -Path $connectionXMLDirectory -Force
+$connectionXMLLocation = "${connectionXMLDirectory}\connections.xml"
+$connectionXMLContents = Get-Content -Path "C:\scripts\connections.xml"
+$connectionXMLContents | Out-File -FilePath $connectionXMLLocation

--- a/teams/delius-iaps/components/iaps_server/delius_iaps_install_oracle_sql_developer.yml
+++ b/teams/delius-iaps/components/iaps_server/delius_iaps_install_oracle_sql_developer.yml
@@ -41,3 +41,36 @@ phases:
               $Shortcut = $WshShell.CreateShortcut("C:\Users\Public\Desktop\SQLDeveloper.lnk")
               $Shortcut.TargetPath = "${env:ProgramData}\sqldeveloper-4.1.3.20.78-x64\sqldeveloper\sqldeveloper.exe"
               $Shortcut.Save()
+
+      - name: CreateScriptsDirectory
+        action: ExecutePowerShell
+        inputs:
+          commands:
+            - |
+              $ErrorActionPreference = "Stop"
+              $VerbosePreference = "Continue"
+
+              New-Item -ItemType Directory -Path "C:\scripts" -Force
+      - name: DownloadTemplateConnectionXML
+        action: WebDownload
+        onFailure: Abort
+        inputs:
+          - source: "https://github.com/ministryofjustice/modernisation-platform-ami-builds/raw/main/teams/delius-iaps/components/files/connections.xml"
+            destination: C:\scripts\connections.xml
+            ignoreCertificateErrors: true
+
+      - name: DownloadSQLConnectionBootstrapPS1
+        action: WebDownload
+        onFailure: Abort
+        inputs:
+          - source: "https://github.com/ministryofjustice/modernisation-platform-ami-builds/raw/main/teams/delius-iaps/components/files/login.ps1"
+            destination: C:\scripts\login.ps1
+            ignoreCertificateErrors: true
+
+      - name: DownloadSQLConnectionBootstrapBAT
+        action: WebDownload
+        onFailure: Abort
+        inputs:
+          - source: "https://github.com/ministryofjustice/modernisation-platform-ami-builds/raw/main/teams/delius-iaps/components/files/login.cmd"
+            destination: "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\StartUp\login.cmd"
+            ignoreCertificateErrors: true

--- a/teams/delius-iaps/components/iaps_server/delius_iaps_install_oracle_sql_developer.yml
+++ b/teams/delius-iaps/components/iaps_server/delius_iaps_install_oracle_sql_developer.yml
@@ -57,7 +57,7 @@ phases:
         inputs:
           - source: "https://github.com/ministryofjustice/modernisation-platform-ami-builds/raw/main/teams/delius-iaps/components/files/connections.xml"
             destination: C:\scripts\connections.xml
-            ignoreCertificateErrors: true
+            ignoreCertificateErrors: false
 
       - name: DownloadSQLConnectionBootstrapPS1
         action: WebDownload
@@ -65,7 +65,7 @@ phases:
         inputs:
           - source: "https://github.com/ministryofjustice/modernisation-platform-ami-builds/raw/main/teams/delius-iaps/components/files/login.ps1"
             destination: C:\scripts\login.ps1
-            ignoreCertificateErrors: true
+            ignoreCertificateErrors: false
 
       - name: DownloadSQLConnectionBootstrapBAT
         action: WebDownload
@@ -73,4 +73,4 @@ phases:
         inputs:
           - source: "https://github.com/ministryofjustice/modernisation-platform-ami-builds/raw/main/teams/delius-iaps/components/files/login.cmd"
             destination: "C:\ProgramData\\Microsoft\\Windows\\Start Menu\Programs\\StartUp\\login.cmd"
-            ignoreCertificateErrors: true
+            ignoreCertificateErrors: false

--- a/teams/delius-iaps/components/iaps_server/delius_iaps_install_oracle_sql_developer.yml
+++ b/teams/delius-iaps/components/iaps_server/delius_iaps_install_oracle_sql_developer.yml
@@ -72,5 +72,5 @@ phases:
         onFailure: Abort
         inputs:
           - source: "https://github.com/ministryofjustice/modernisation-platform-ami-builds/raw/main/teams/delius-iaps/components/files/login.cmd"
-            destination: "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\StartUp\login.cmd"
+            destination: "C:\ProgramData\\Microsoft\\Windows\\Start Menu\Programs\\StartUp\\login.cmd"
             ignoreCertificateErrors: true


### PR DESCRIPTION
* Add new required files which will automatically provide users logging in with a valid SQL connections file which will prevent the need for them to manually configure it. 

* Connections.xml is templated in the AMI build and the user data for the instance will replace placeholder values with ones valid in the given environment as they will be known

* Update install oracle sql developer component to move templated connections file and relevant scripts to run on user log in into the right locations