### PR TITLE
IAPS: Check if connections.xml exists before trying to overwrite it

### DIFF
--- a/teams/delius-iaps/components/files/login.ps1
+++ b/teams/delius-iaps/components/files/login.ps1
@@ -1,5 +1,7 @@
 $connectionXMLDirectory = "C:\Users\$($ENV:USERNAME)\AppData\Roaming\SQL Developer\system4.1.3.20.78\o.jdeveloper.db.connection.12.2.1.0.42.151001.541"
-New-Item -ItemType Directory -Path $connectionXMLDirectory -Force
-$connectionXMLLocation = "${connectionXMLDirectory}\connections.xml"
-$connectionXMLContents = Get-Content -Path "C:\scripts\connections.xml"
-$connectionXMLContents | Out-File -FilePath $connectionXMLLocation
+$connectionsXMLFullPath = "${connectionXMLDirectory}\connections.xml"
+if (![System.IO.File]::Exists($connectionsXMLFullPath)) {
+    New-Item -ItemType Directory -Path $connectionXMLDirectory -Force
+    $connectionXMLContents = Get-Content -Path "C:\scripts\connections.xml"
+    $connectionXMLContents | Out-File -FilePath $connectionsXMLFullPath
+}


### PR DESCRIPTION
This is to prevent overwriting any saved encrypted passwords that Oracle SQL Developer might have placed there