### PR TITLE
Nomis: DSOS-1363: rhel 8.5 base fix

### DIFF
--- a/commonimages/base/rhel_8_5/locals.tf
+++ b/commonimages/base/rhel_8_5/locals.tf
@@ -3,10 +3,6 @@ locals {
 
   components_common = [
     {
-      name       = "python_3_9"
-      version    = "0.0.3"
-      parameters = []
-      }, {
       name    = "ansible"
       version = "0.0.6"
       parameters = [{

--- a/commonimages/base/rhel_8_5/locals.tf
+++ b/commonimages/base/rhel_8_5/locals.tf
@@ -8,7 +8,7 @@ locals {
       parameters = []
       }, {
       name    = "ansible"
-      version = "0.0.5"
+      version = "0.0.6"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/commonimages/base/rhel_8_5/terraform.tfvars
+++ b/commonimages/base/rhel_8_5/terraform.tfvars
@@ -1,7 +1,7 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.0.5"
+configuration_version = "0.0.6"
 description           = "shared rhel 8.5 base image"
 
 ami_base_name = "rhel_8_5"

--- a/commonimages/base/rhel_8_5/terraform.tfvars
+++ b/commonimages/base/rhel_8_5/terraform.tfvars
@@ -1,7 +1,7 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.0.3"
+configuration_version = "0.0.4"
 description           = "shared rhel 8.5 base image"
 
 ami_base_name = "rhel_8_5"

--- a/commonimages/base/rhel_8_5/terraform.tfvars
+++ b/commonimages/base/rhel_8_5/terraform.tfvars
@@ -1,7 +1,7 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.0.4"
+configuration_version = "0.0.5"
 description           = "shared rhel 8.5 base image"
 
 ami_base_name = "rhel_8_5"

--- a/commonimages/components/templates/ansible.yml
+++ b/commonimages/components/templates/ansible.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.5
+      default: 0.0.6
       description: "Component version, increment if you make changes."
   - Platform:
       type: string
@@ -63,13 +63,20 @@ phases:
                 git clone -b $branch "https://github.com/ministryofjustice/$repo.git"
 
                 # set python version
+                # check if already installed (e.g. RHEL6/7 via python component)
                 if [[ $(which python3.9 2> /dev/null) ]]; then
                   python=$(which python3.9)
                 elif [[ $(which python3.6 2> /dev/null) ]]; then
                   python=$(which python3.6)
                 else
-                  echo "Python3.9/3.6 not found"
-                  exit 1
+                  # otherwise just install via yum
+                  yum install -y python39 || true
+                  if [[ $(which python3.9 2> /dev/null) ]]; then
+                    python=$(which python3.9)
+                  else
+                    echo "Python3.9/3.6 not found"
+                    exit 1
+                  fi
                 fi
                 echo "python: $python"
 


### PR DESCRIPTION
Fix some issues with the RHEL8.5 base image:
- no need for python component as python3.9 can be installed via yum
- update ansible component to support python3.9 installation via yum
Tested with image in nomis-development