### PR TITLE
Nomis/dsos 1797/jumpserver edge improvements

### DIFF
--- a/teams/nomis/components/windows_server_2019_jumpserver/jumpserver_2019.yml
+++ b/teams/nomis/components/windows_server_2019_jumpserver/jumpserver_2019.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 1.0.4
+      default: 1.0.5
       description: Component version (update this each time the file changes)
   - Platform:
       type: string

--- a/teams/nomis/components/windows_server_2019_jumpserver/jumpserver_2019.yml
+++ b/teams/nomis/components/windows_server_2019_jumpserver/jumpserver_2019.yml
@@ -80,7 +80,7 @@ phases:
               # Turn on Edge IE Mode using reg_path from previous step
               New-ItemProperty -Path $reg_path -Name InternetExplorerIntegrationLevel -Value 1 -PropertyType DWORD -Force
 
-              @compatibility_site_list = @(
+              $compatibility_site_list = @(
                   "t1-nomis-web-a.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
                   "t1-nomis-web-a.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
                   "t1-nomis-web-b.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
@@ -154,10 +154,10 @@ phases:
                 $root.AppendChild($siteElement)
               }
 
-              $xmlDoc.Save($site_list_path)
+              $xmlDoc.Save($compatibility_site_list_path)
 
               # Add compatibility list to registry
-              New-ItemProperty -Path $reg_path -Name InternetExplorerIntegrationSiteList -Value $site_list_path -PropertyType String -Force
+              New-ItemProperty -Path $reg_path -Name InternetExplorerIntegrationSiteList -Value $compatibility_site_list_path -PropertyType String -Force
 
               # Allow popups for .justice.gov.uk urls
               $reg_path = "HKLM:\SOFTWARE\Policies\Microsoft\Edge\PopupsAllowedForUrls"

--- a/teams/nomis/components/windows_server_2019_jumpserver/jumpserver_2019.yml
+++ b/teams/nomis/components/windows_server_2019_jumpserver/jumpserver_2019.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 1.0.3
+      default: 1.0.4
       description: Component version (update this each time the file changes)
   - Platform:
       type: string

--- a/teams/nomis/components/windows_server_2019_jumpserver/jumpserver_2019.yml
+++ b/teams/nomis/components/windows_server_2019_jumpserver/jumpserver_2019.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 1.0.2
+      default: 1.0.3
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -41,11 +41,13 @@ phases:
             - |
               # Add Nomis sites to trusted sites
               $sites = @(
-                  "*.nomis.hmpps-test.modernisation-platform.internal"
+                  "*.nomis.hmpps-development.modernisation-platform.justice.gov.uk"
                   "*.nomis.hmpps-test.modernisation-platform.justice.gov.uk"
-                  "*.nomis.hmpps-production.modernisation-platform.internal"
+                  "*.nomis.hmpps-preproduction.modernisation-platform.justice.gov.uk"
                   "*.nomis.hmpps-production.modernisation-platform.justice.gov.uk"
-                  "*.modernisation-platform.nomis.az.justice.gov.uk"
+                  "*.nomis.service.justice.gov.uk"
+                  "*.nomis.az.justice.gov.uk"
+                  "*.hmpp-azdt.justice.gov.uk"
               )
 
               $paths = @(
@@ -65,6 +67,114 @@ phases:
               $reg_path = "HKLM:\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings"
               New-Item -Path $reg_path -Force
               New-ItemProperty -Path $reg_path -Name Security_HKLM_only -Value 1 -PropertyType DWORD -Force
+      - name: ConfigureEdge
+        action: ExecutePowerShell
+        inputs:
+          commands:
+            - |
+              # Turn off Edge first run experience
+              $reg_path = "HKLM:\SOFTWARE\Policies\Microsoft\Edge"
+              New-Item -Path $reg_path -Force
+              New-ItemProperty -Path $reg_path -Name HideFirstRunExperience -Value 1 -PropertyType DWORD -Force
+
+              # Turn on Edge IE Mode using reg_path from previous step
+              New-ItemProperty -Path $reg_path -Name InternetExplorerIntegrationLevel -Value 1 -PropertyType DWORD -Force
+
+              @compatibility_site_list = @(
+                  "t1-nomis-web-a.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t1-nomis-web-a.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t1-nomis-web-b.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t1-nomis-web-b.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t1-cn.hmpp-azdt.justice.gov.uk:7777/forms/frmservlet?config=tag"
+                  "t1-cn.hmpp-azdt.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c-t1.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c-t1.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t2-nomis-web-a.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t2-nomis-web-a.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t2-nomis-web-b.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t2-nomis-web-b.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t2-cn.hmpp-azdt.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c-t2.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c-t2.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t3-nomis-web-a.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t3-nomis-web-a.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t3-nomis-web-b.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t3-nomis-web-b.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t3-cn.hmpp-azdt.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t3-cn-ha.hmpp-azdt.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c-t3.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c-t3.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "preprod-nomis-web-a.preproduction.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "preprod-nomis-web-a.preproduction.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "preprod-nomis-web-b.preproduction.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "preprod-nomis-web-b.preproduction.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c.pp-nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c.preproduction.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c.preproduction.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "prod-nomis-web-a.production.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "prod-nomis-web-a.production.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "prod-nomis-web-b.production.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "prod-nomis-web-b.production.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c.production.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c.production.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              )
+
+              # Add sites to Edge IE Mode compatibility list
+              $compatibility_site_list_path = "C:\\compatibility_site_list.xml"
+
+              $xmlDoc = New-Object System.Xml.XmlDocument
+              $root = $xmlDoc.CreateElement("site-list")
+              $root.SetAttribute('version', 1)
+              $xmlDoc.AppendChild($root)
+
+              $created_byElement = $xmlDoc.CreateElement("created-by")
+
+              $toolElement = $xmlDoc.CreateElement("tool")
+              $versionElement = $xmlDoc.CreateElement("version")
+              $date_createdElement = $xmlDoc.CreateElement("date_created")
+              $toolElement.InnerText = "EMIESiteListManager"
+              $versionElement.InnerText = "10.0.0.0"
+              $date_createdElement.InnerText = $(Get-Date -Format "MM/dd/yyyy hh:mm:ss")
+              $created_byElement.AppendChild($toolElement)
+              $created_byElement.AppendChild($versionElement)
+              $created_byElement.AppendChild($date_createdElement)
+              $root.AppendChild($created_byElement)
+
+              foreach ($site in $compatibility_site_list) {
+                $siteElement = $xmlDoc.CreateElement("site")
+                $siteElement.SetAttribute('url', $site)
+                $compatModeElement = $xmlDoc.CreateElement("compat-mode")
+                $openInElement = $xmlDoc.CreateElement("open-in")
+                $compatModeElement.InnerText = "Default"
+                $openInElement.InnerText = "IE11"
+                $siteElement.AppendChild($compatModeElement)
+                $siteElement.AppendChild($openInElement)
+                $root.AppendChild($siteElement)
+              }
+
+              $xmlDoc.Save($site_list_path)
+
+              # Add compatibility list to registry
+              New-ItemProperty -Path $reg_path -Name InternetExplorerIntegrationSiteList -Value $site_list_path -PropertyType String -Force
+
+              # Allow popups for .justice.gov.uk urls
+              $reg_path = "HKLM:\SOFTWARE\Policies\Microsoft\Edge\PopupsAllowedForUrls"
+              New-Item -Path $reg_path -Force
+              New-ItemProperty -Path $reg_path -Name 1 -Value "[*.]justice.gov.uk" -PropertyType String -Force
+      - name: ConfigureDesktopShortcut
+        action: ExecutePowerShell  
+        inputs:
+          commands:
+            - |  
+              # Create Desktop Shortcut to Nomis
+              $new_object = New-Object -ComObject WScript.Shell
+              $destination = $new_object.SpecialFolders.Item("AllUsersDesktop")
+              $source_path = Join-Path -Path $destination -ChildPath "\\C-Nomis.url"
+              $source = $new_object.CreateShortcut($source_path)
+              $source.TargetPath = "https://c-t1.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              $source.Save()
       - name: ConfigureSQLDeveloper
         action: ExecutePowerShell
         inputs:

--- a/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
+++ b/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
@@ -80,7 +80,7 @@ phases:
               # Turn on Edge IE Mode using reg_path from previous step
               New-ItemProperty -Path $reg_path -Name InternetExplorerIntegrationLevel -Value 1 -PropertyType DWORD -Force
 
-              @compatibility_site_list = @(
+              $compatibility_site_list = @(
                   "t1-nomis-web-a.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
                   "t1-nomis-web-a.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
                   "t1-nomis-web-b.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
@@ -154,10 +154,10 @@ phases:
                 $root.AppendChild($siteElement)
               }
 
-              $xmlDoc.Save($site_list_path)
+              $xmlDoc.Save($compatibility_site_list_path)
 
               # Add compatibility list to registry
-              New-ItemProperty -Path $reg_path -Name InternetExplorerIntegrationSiteList -Value $site_list_path -PropertyType String -Force
+              New-ItemProperty -Path $reg_path -Name InternetExplorerIntegrationSiteList -Value $compatibility_site_list_path -PropertyType String -Force
 
               # Allow popups for .justice.gov.uk urls
               $reg_path = "HKLM:\SOFTWARE\Policies\Microsoft\Edge\PopupsAllowedForUrls"

--- a/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
+++ b/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 1.0.15
+      default: 1.0.16
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -41,11 +41,13 @@ phases:
             - |
               # Add Nomis sites to trusted sites
               $sites = @(
-                  "*.nomis.hmpps-test.modernisation-platform.internal"
+                  "*.nomis.hmpps-development.modernisation-platform.justice.gov.uk"
                   "*.nomis.hmpps-test.modernisation-platform.justice.gov.uk"
-                  "*.nomis.hmpps-production.modernisation-platform.internal"
+                  "*.nomis.hmpps-preproduction.modernisation-platform.justice.gov.uk"
                   "*.nomis.hmpps-production.modernisation-platform.justice.gov.uk"
-                  "*.modernisation-platform.nomis.az.justice.gov.uk"
+                  "*.nomis.service.justice.gov.uk"
+                  "*.nomis.az.justice.gov.uk"
+                  "*.hmpp-azdt.justice.gov.uk"
               )
 
               $paths = @(
@@ -65,6 +67,114 @@ phases:
               $reg_path = "HKLM:\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings"
               New-Item -Path $reg_path -Force
               New-ItemProperty -Path $reg_path -Name Security_HKLM_only -Value 1 -PropertyType DWORD -Force
+      - name: ConfigureEdge
+        action: ExecutePowerShell
+        inputs:
+          commands:
+            - |
+              # Turn off Edge first run experience
+              $reg_path = "HKLM:\SOFTWARE\Policies\Microsoft\Edge"
+              New-Item -Path $reg_path -Force
+              New-ItemProperty -Path $reg_path -Name HideFirstRunExperience -Value 1 -PropertyType DWORD -Force
+
+              # Turn on Edge IE Mode using reg_path from previous step
+              New-ItemProperty -Path $reg_path -Name InternetExplorerIntegrationLevel -Value 1 -PropertyType DWORD -Force
+
+              @compatibility_site_list = @(
+                  "t1-nomis-web-a.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t1-nomis-web-a.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t1-nomis-web-b.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t1-nomis-web-b.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t1-cn.hmpp-azdt.justice.gov.uk:7777/forms/frmservlet?config=tag"
+                  "t1-cn.hmpp-azdt.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c-t1.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c-t1.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t2-nomis-web-a.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t2-nomis-web-a.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t2-nomis-web-b.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t2-nomis-web-b.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t2-cn.hmpp-azdt.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c-t2.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c-t2.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t3-nomis-web-a.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t3-nomis-web-a.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t3-nomis-web-b.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t3-nomis-web-b.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t3-cn.hmpp-azdt.justice.gov.uk/forms/frmservlet?config=tag"
+                  "t3-cn-ha.hmpp-azdt.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c-t3.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c-t3.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "preprod-nomis-web-a.preproduction.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "preprod-nomis-web-a.preproduction.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "preprod-nomis-web-b.preproduction.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "preprod-nomis-web-b.preproduction.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c.pp-nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c.preproduction.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c.preproduction.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "prod-nomis-web-a.production.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "prod-nomis-web-a.production.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "prod-nomis-web-b.production.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "prod-nomis-web-b.production.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c.production.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c.production.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+                  "c.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              )
+
+              # Add sites to Edge IE Mode compatibility list
+              $compatibility_site_list_path = "C:\\compatibility_site_list.xml"
+
+              $xmlDoc = New-Object System.Xml.XmlDocument
+              $root = $xmlDoc.CreateElement("site-list")
+              $root.SetAttribute('version', 1)
+              $xmlDoc.AppendChild($root)
+
+              $created_byElement = $xmlDoc.CreateElement("created-by")
+
+              $toolElement = $xmlDoc.CreateElement("tool")
+              $versionElement = $xmlDoc.CreateElement("version")
+              $date_createdElement = $xmlDoc.CreateElement("date_created")
+              $toolElement.InnerText = "EMIESiteListManager"
+              $versionElement.InnerText = "10.0.0.0"
+              $date_createdElement.InnerText = $(Get-Date -Format "MM/dd/yyyy hh:mm:ss")
+              $created_byElement.AppendChild($toolElement)
+              $created_byElement.AppendChild($versionElement)
+              $created_byElement.AppendChild($date_createdElement)
+              $root.AppendChild($created_byElement)
+
+              foreach ($site in $compatibility_site_list) {
+                $siteElement = $xmlDoc.CreateElement("site")
+                $siteElement.SetAttribute('url', $site)
+                $compatModeElement = $xmlDoc.CreateElement("compat-mode")
+                $openInElement = $xmlDoc.CreateElement("open-in")
+                $compatModeElement.InnerText = "Default"
+                $openInElement.InnerText = "IE11"
+                $siteElement.AppendChild($compatModeElement)
+                $siteElement.AppendChild($openInElement)
+                $root.AppendChild($siteElement)
+              }
+
+              $xmlDoc.Save($site_list_path)
+
+              # Add compatibility list to registry
+              New-ItemProperty -Path $reg_path -Name InternetExplorerIntegrationSiteList -Value $site_list_path -PropertyType String -Force
+
+              # Allow popups for .justice.gov.uk urls
+              $reg_path = "HKLM:\SOFTWARE\Policies\Microsoft\Edge\PopupsAllowedForUrls"
+              New-Item -Path $reg_path -Force
+              New-ItemProperty -Path $reg_path -Name 1 -Value "[*.]justice.gov.uk" -PropertyType String -Force
+      - name: ConfigureDesktopShortcut
+        action: ExecutePowerShell  
+        inputs:
+          commands:
+            - |  
+              # Create Desktop Shortcut to Nomis
+              $new_object = New-Object -ComObject WScript.Shell
+              $destination = $new_object.SpecialFolders.Item("AllUsersDesktop")
+              $source_path = Join-Path -Path $destination -ChildPath "\\C-Nomis.url"
+              $source = $new_object.CreateShortcut($source_path)
+              $source.TargetPath = "https://c-t1.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              $source.Save()
       - name: ConfigureSQLDeveloper
         action: ExecutePowerShell
         inputs:

--- a/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
+++ b/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
@@ -147,6 +147,7 @@ phases:
                 $siteElement.SetAttribute('url', $site)
                 $compatModeElement = $xmlDoc.CreateElement("compat-mode")
                 $openInElement = $xmlDoc.CreateElement("open-in")
+                $openInElement.SetAttribute('allow-redirect', 'true')
                 $compatModeElement.InnerText = "Default"
                 $openInElement.InnerText = "IE11"
                 $siteElement.AppendChild($compatModeElement)

--- a/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
+++ b/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 1.0.17
+      default: 1.0.18
       description: Component version (update this each time the file changes)
   - Platform:
       type: string

--- a/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
+++ b/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 1.0.16
+      default: 1.0.17
       description: Component version (update this each time the file changes)
   - Platform:
       type: string

--- a/teams/nomis/windows_server_2019_jumpserver/terraform.tfvars
+++ b/teams/nomis/windows_server_2019_jumpserver/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "windows_server_2019_jumpserver"
-configuration_version = "0.0.4"
+configuration_version = "0.0.5"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2019 jumpserver"
 

--- a/teams/nomis/windows_server_2019_jumpserver/terraform.tfvars
+++ b/teams/nomis/windows_server_2019_jumpserver/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "windows_server_2019_jumpserver"
-configuration_version = "0.0.5"
+configuration_version = "0.0.6"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2019 jumpserver"
 

--- a/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
+++ b/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "windows_server_2022_jumpserver"
-configuration_version = "0.4.0"
+configuration_version = "0.4.1"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2022 jumpserver"
 

--- a/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
+++ b/teams/nomis/windows_server_2022_jumpserver/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "windows_server_2022_jumpserver"
-configuration_version = "0.3.9"
+configuration_version = "0.4.0"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2022 jumpserver"
 


### PR DESCRIPTION
Checked jumpserver performance - seems very good

Also 'quality of life' improvements using the jumpserver (Edge) browser to access Nomis
- Shortcut on desktop
- Block 'welcome to Edge' first run browser behaviour
- Ensure IE compatibility mode is on for internal site list
- Allow pop-ups within our domain