### PR TITLE
install libreoffice to allow opening of pdf and word docs

### DIFF
--- a/teams/nomis/components/windows_server_2019_jumpserver/jumpserver_2019.yml
+++ b/teams/nomis/components/windows_server_2019_jumpserver/jumpserver_2019.yml
@@ -193,3 +193,9 @@ phases:
               $shortcut_link = $shortcut.CreateShortcut("C:\Users\Public\Desktop\SQL Developer.lnk")
               $shortcut_link.TargetPath = "C:\Program Files\Oracle\sqldeveloper\sqldeveloper.exe"
               $shortcut_link.Save()
+      - name: InstallLibreOffice
+        actions: ExecutePowerShell
+        inputs:
+          commands:
+            - |
+              choco install -y libreoffice-still

--- a/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
+++ b/teams/nomis/components/windows_server_2022_jumpserver/jumpserver.yml
@@ -194,3 +194,9 @@ phases:
               $shortcut_link = $shortcut.CreateShortcut("C:\Users\Public\Desktop\SQL Developer.lnk")
               $shortcut_link.TargetPath = "C:\Program Files\Oracle\sqldeveloper\sqldeveloper.exe"
               $shortcut_link.Save()
+      - name: InstallLibreOffice
+        actions: ExecutePowerShell
+        inputs:
+          commands:
+            - |
+              choco install -y libreoffice-still


### PR DESCRIPTION
libreoffice-still is the version which has undergone more testing for a longer time and is recommended for more conservative users

LibreOffice install creates a desktop shortcut and allows users to read pdf’s as well as open/edit word (and other) docs. This avoids a LOT of palaver associated with Microsoft’s Office Suite and licensing since there’s no longer a ‘standalone’ version of Word available to install from anywhere. LibreOffice is Apache/Mozilla licensed therefore is absolutely free.