### PR TITLE
AWS Provider 5.0 upgrade

### DIFF
--- a/commonimages/base/versions.tf
+++ b/commonimages/base/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = "=1.3.3"

--- a/commonimages/components/versions.tf
+++ b/commonimages/components/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = "=1.3.3"

--- a/modernisation-platform/versions.tf
+++ b/modernisation-platform/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = "~> 1.0"

--- a/modules/imagebuilder/versions.tf
+++ b/modules/imagebuilder/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = "=1.3.3"

--- a/teams/delius-core/versions.tf
+++ b/teams/delius-core/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = "=1.3.3"

--- a/teams/delius-iaps/versions.tf
+++ b/teams/delius-iaps/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = "=1.3.3"

--- a/teams/example/versions.tf
+++ b/teams/example/versions.tf
@@ -1,9 +1,8 @@
 terraform {
-  experiments = [module_variable_optional_attrs]
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = "~> 1.0"

--- a/teams/nomis-data-hub/versions.tf
+++ b/teams/nomis-data-hub/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = "=1.3.3"

--- a/teams/nomis/versions.tf
+++ b/teams/nomis/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = "=1.3.3"

--- a/teams/oasys/versions.tf
+++ b/teams/oasys/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = "=1.3.3"

--- a/teams/onr/versions.tf
+++ b/teams/onr/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = "=1.3.3"

--- a/teams/sprinkler/versions.tf
+++ b/teams/sprinkler/versions.tf
@@ -1,9 +1,8 @@
 terraform {
-  experiments = [module_variable_optional_attrs]
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = "~> 1.0"


### PR DESCRIPTION
* Bumps `version` constraint to `~> 5.0`.
Related to https://github.com/ministryofjustice/modernisation-platform/issues/4173