### PR TITLE
Nomis/dsos 1884/fix rhel6 base ami

### DIFF
--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -24,6 +24,7 @@ parent_image = {
   arn_resource_id = "base-rhel-6-10/0.1.0"
 }
 
+
 # rhel6.10 cannot use amazon-ssm-agent, this is installed via user_data
 components_aws = [
   "update-linux",

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -2,7 +2,7 @@
 # BRANCH_NAME =
 # GH_ACTOR_NAME =
 
-configuration_version = "0.1.1"
+configuration_version = "0.1.2"
 description           = "shared rhel 6.10 base image"
 
 ami_base_name = "rhel_6_10"

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -14,14 +14,14 @@ tags = {
 
 parent_image = {
   # Official Redhat image now only available in named accounts
-  # owner = "679593333241" # Redhat
-  # ami_search_filters = {
-  #   name = ["RHEL-6.10_HVM-*"]
-  # }
-
+  owner = "679593333241" # Redhat
+  ami_search_filters = {
+    name = ["RHEL-6.10_HVM-*"]
+  }
+  include_deprecated = true
   # Just to keep the pipeline going, reference a previous base rhel6 as the base
-  owner           = "core-shared-services-production"
-  arn_resource_id = "base-rhel-6-10/0.1.0"
+  # owner           = "core-shared-services-production"
+  # arn_resource_id = "base-rhel-6-10/0.1.0"
 }
 
 

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -2,7 +2,7 @@
 # BRANCH_NAME =
 # GH_ACTOR_NAME =
 
-configuration_version = "0.1.2"
+configuration_version = "0.2.0"
 description           = "shared rhel 6.10 base image"
 
 ami_base_name = "rhel_6_10"
@@ -13,15 +13,12 @@ tags = {
 }
 
 parent_image = {
-  # Official Redhat image now only available in named accounts
+  # Red Hat Enterprise Linux 6.10 with Extended Lifecycle Support through June 30, 2024
   owner = "679593333241" # Redhat
   ami_search_filters = {
     name = ["RHEL-6.10_HVM-*"]
   }
   include_deprecated = true
-  # Just to keep the pipeline going, reference a previous base rhel6 as the base
-  # owner           = "core-shared-services-production"
-  # arn_resource_id = "base-rhel-6-10/0.1.0"
 }
 
 

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -2,7 +2,7 @@
 # BRANCH_NAME =
 # GH_ACTOR_NAME =
 
-configuration_version = "0.1.0"
+configuration_version = "0.1.1"
 description           = "shared rhel 6.10 base image"
 
 ami_base_name = "rhel_6_10"

--- a/commonimages/base/variables.tf
+++ b/commonimages/base/variables.tf
@@ -31,6 +31,7 @@ variable "parent_image" {
     owner              = string                      # either an ID or a name which is a key in var.account_ids_lookup
     ami_search_filters = optional(map(list(string))) # search for an ami, where the map key is the filter name and the map value is the filter values
     arn_resource_id    = optional(string)
+    image-id           = optional(string)
   })
   description = "The image this ami will be based on"
 }

--- a/commonimages/base/variables.tf
+++ b/commonimages/base/variables.tf
@@ -31,7 +31,7 @@ variable "parent_image" {
     owner              = string                      # either an ID or a name which is a key in var.account_ids_lookup
     ami_search_filters = optional(map(list(string))) # search for an ami, where the map key is the filter name and the map value is the filter values
     arn_resource_id    = optional(string)
-    image-id           = optional(string)
+    include_deprecated = optional(bool)
   })
   description = "The image this ami will be based on"
 }

--- a/modules/imagebuilder/data.tf
+++ b/modules/imagebuilder/data.tf
@@ -38,9 +38,9 @@ data "aws_imagebuilder_component" "this" {
 }
 
 data "aws_ami" "parent" {
-  count       = var.parent_image.ami_search_filters != null ? 1 : 0
-  most_recent = true
-  owners      = [local.ami_parent_id]
+  count              = var.parent_image.ami_search_filters != null ? 1 : 0
+  most_recent        = true
+  owners             = [local.ami_parent_id]
   include_deprecated = var.parent_image.include_deprecated
 
   dynamic "filter" {

--- a/modules/imagebuilder/data.tf
+++ b/modules/imagebuilder/data.tf
@@ -41,7 +41,7 @@ data "aws_ami" "parent" {
   count       = var.parent_image.ami_search_filters != null ? 1 : 0
   most_recent = true
   owners      = [local.ami_parent_id]
-  include_deprecated = true
+  include_deprecated = var.parent_image.include_deprecated
 
   dynamic "filter" {
     for_each = var.parent_image.ami_search_filters

--- a/modules/imagebuilder/data.tf
+++ b/modules/imagebuilder/data.tf
@@ -41,6 +41,7 @@ data "aws_ami" "parent" {
   count       = var.parent_image.ami_search_filters != null ? 1 : 0
   most_recent = true
   owners      = [local.ami_parent_id]
+  include_deprecated = true
 
   dynamic "filter" {
     for_each = var.parent_image.ami_search_filters

--- a/modules/imagebuilder/variables.tf
+++ b/modules/imagebuilder/variables.tf
@@ -91,6 +91,7 @@ variable "parent_image" {
     owner              = string                      # either an ID or a name which is a key in var.account_ids_lookup
     ami_search_filters = optional(map(list(string))) # search for an ami, where the map key is the filter name and the map value is the filter values
     arn_resource_id    = optional(string)            # or specify an AMI ARN directly (the last part of ARN after arm:aws:imagebuilder:{region}:{account-id}:image/)
+    include_deprecated = optional(bool)              # include deprecated images in the search
   })
   description = "The image this ami will be based on"
 }


### PR DESCRIPTION
- uses Red Hat Enterprise Linux 6.10 with Extended Lifecycle Support ami
- this gets us support through till June 30, 2024
- set ami recipe version to 0.2.0 to indicate this is NOT using our own "pre-built" ami anymore