### PR TITLE
DSOS-2055: distribute oracle19 AMI to combined reporting accounts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,4 @@
 /teams/onr @ministryofjustice/studio-webops
 /teams/example @ministryofjustice/modernisation-platform
 /teams/sprinkler @ministryofjustice/modernisation-platform
+/teams/hmpps @ministryofjustice/studio-webops @ministryofjustice/hmpps-migration

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 /teams/onr @ministryofjustice/studio-webops
 /teams/example @ministryofjustice/modernisation-platform
 /teams/sprinkler @ministryofjustice/modernisation-platform
-/teams/hmpps @ministryofjustice/studio-webops @ministryofjustice/hmpps-migration
+/teams/hmpps @ministryofjustice/studio-webops @ministryofjustice/hmpps-migration @ministryofjustice/modernisation-platform

--- a/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
+++ b/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "ol_8_5_oracledb_19c"
-configuration_version = "0.0.1"
+configuration_version = "0.0.2"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "hmpps oracle 19c image on oracle linux 8.5"
 
@@ -140,6 +140,10 @@ launch_permission_accounts_by_branch = {
     "corporate-staff-rostering-test",
     "corporate-staff-rostering-preproduction",
     "corporate-staff-rostering-production",
+    "nomis-combined-reporting-development",
+    "nomis-combined-reporting-test",
+    "nomis-combined-reporting-preproduction",
+    "nomis-combined-reporting-production",
   ]
 
   # push to any other branch / local run
@@ -151,6 +155,8 @@ launch_permission_accounts_by_branch = {
     "hmpps-oem-test",
     "corporate-staff-rostering-development",
     "corporate-staff-rostering-test",
+    "nomis-combined-reporting-development",
+    "nomis-combined-reporting-test",
   ]
 }
 


### PR DESCRIPTION
Copy Oracle 19c AMI into combined reporting accounts as well
Updated CODEOWNERS for hmpps team to include DSO and ProbationWebOps 