### PR TITLE
DSOS-2055: make oracle 19c available to combined reporting v2

### DIFF
--- a/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
+++ b/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "ol_8_5_oracledb_19c"
-configuration_version = "0.0.2"
+configuration_version = "0.0.3"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "hmpps oracle 19c image on oracle linux 8.5"
 

--- a/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
+++ b/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
@@ -110,6 +110,10 @@ accounts_to_distribute_ami_by_branch = {
     "corporate-staff-rostering-test",
     "corporate-staff-rostering-preproduction",
     "corporate-staff-rostering-production",
+    "nomis-combined-reporting-development",
+    "nomis-combined-reporting-test",
+    "nomis-combined-reporting-preproduction",
+    "nomis-combined-reporting-production",
   ]
 
   # push to any other branch / local run
@@ -121,6 +125,8 @@ accounts_to_distribute_ami_by_branch = {
     "hmpps-oem-test",
     "corporate-staff-rostering-development",
     "corporate-staff-rostering-test",
+    "nomis-combined-reporting-development",
+    "nomis-combined-reporting-test",
   ]
 }
 


### PR DESCRIPTION
Only updated launch permissions in last PR.  Need these distribution settings as well to allow oracle19c AMI to run in combined reporting.