### PR TITLE
Add rhel 8 to hmpps domain services

### DIFF
--- a/commonimages/base/shared.auto.tfvars
+++ b/commonimages/base/shared.auto.tfvars
@@ -27,6 +27,7 @@ launch_permission_account_names = [
   "hmpps-oem-preproduction",
   "hmpps-oem-production",
   "hmpps-oem-test",
+  "hmpps-domain-services-test",
   "nomis-combined-reporting-development",
   "nomis-combined-reporting-preproduction",
   "nomis-combined-reporting-production",

--- a/teams/hmpps/rhel_8_5/locals.tf
+++ b/teams/hmpps/rhel_8_5/locals.tf
@@ -1,0 +1,19 @@
+locals {
+
+  components_common = [
+    {
+      name    = "ansible"
+      version = "0.0.6"
+      parameters = [{
+        name  = "Ami"
+        value = join("_", [var.ami_name_prefix, var.ami_base_name])
+        }, {
+        name  = "Branch"
+        value = "main" # replace main with corresponding ansible branch if you are testing
+      }]
+    }
+  ]
+
+  component_template_args = {}
+
+}

--- a/teams/hmpps/rhel_8_5/terraform.tfvars
+++ b/teams/hmpps/rhel_8_5/terraform.tfvars
@@ -1,0 +1,80 @@
+# following are passed in via pipeline
+# BRANCH_NAME =
+# GH_ACTOR_NAME =
+
+region                = "eu-west-2"
+ami_name_prefix       = "hmpps"
+ami_base_name         = "rhel_8_5_join_to_azure"
+configuration_version = "0.0.1"
+release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
+description           = "hmpps rhel 8.5 join to Azure domain"
+
+tags = {
+  os-version = "rhel 8.5"
+}
+
+parent_image = {
+  owner           = "core-shared-services-production"
+  arn_resource_id = "base-rhel-8-5/x.x.x"
+}
+
+block_device_mappings_ebs = [
+  {
+    device_name = "/dev/sda1" # root volume
+    volume_size = 30
+    volume_type = "gp3"
+  },
+  {
+    device_name = "/dev/sdb" # /u01
+    volume_size = 100
+    volume_type = "gp3"
+  }
+]
+
+components_aws = ["update-linux"]
+
+components_custom = []
+
+systems_manager_agent = {
+  uninstall_after_build = false
+}
+
+infrastructure_configuration = {
+  instance_types = ["t3.medium"]
+}
+
+image_pipeline = {
+  schedule = {
+    schedule_expression = "cron(0 0 2 * ? *)"
+  }
+}
+
+accounts_to_distribute_ami_by_branch = {
+  # push to main branch
+  main = [
+    "core-shared-services-production",
+    "hmpps-domain-services-test"
+  ]
+
+  # push to any other branch / local run
+  default = [
+    "core-shared-services-production",
+    "hmpps-domain-services-test"
+  ]
+}
+
+launch_permission_accounts_by_branch = {
+  # push to main branch
+  main = [
+    "core-shared-services-production",
+    "hmpps-domain-services-test"
+  ]
+
+  # push to any other branch / local run
+  default = [
+    "core-shared-services-production",
+    "hmpps-domain-services-test"
+  ]
+}
+
+launch_template_exists = false

--- a/teams/hmpps/rhel_8_5/terragrunt.hcl
+++ b/teams/hmpps/rhel_8_5/terragrunt.hcl
@@ -1,0 +1,6 @@
+include {
+  path = find_in_parent_folders()
+}
+terraform {
+  source = "../../..//teams/nomis"
+}


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/DSOS-2117

> Create a RHEL 8.5 EC2 instance in the hmpps-domain-services test account.

> Update the modernisation-platform-ami-builds/commonimages/base such that is allows images to be launched in hmpps-domain-services accounts.  You will need to update AMI version numbers for this to work.