### PR TITLE
Increment versions to prevent ResourceAlreadyExistsException

### DIFF
--- a/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
+++ b/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "ol_8_5_oracledb_19c"
-configuration_version = "0.0.3"
+configuration_version = "0.0.4"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "hmpps oracle 19c image on oracle linux 8.5"
 

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
-configuration_version = "0.0.2"
+configuration_version = "0.0.3"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 


### PR DESCRIPTION
Incrementing versions to prevent

```
Error: creating Image Builder Image Recipe: ResourceAlreadyExistsException: The following resource 'ImageRecipe' already exists: 'arn:aws:imagebuilder:eu-west-2:374269020027:image-recipe/base-windows-server-2012/0.0.2'.
```