### PR TITLE
specify ebs volumes on a per-server basis

### DIFF
--- a/commonimages/base/ol_8_5/terraform.tfvars
+++ b/commonimages/base/ol_8_5/terraform.tfvars
@@ -1,7 +1,7 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.0.5"
+configuration_version = "0.0.6"
 description           = "shared oracle linux 8.5 base image"
 
 ami_base_name = "ol_8_5"
@@ -17,6 +17,14 @@ parent_image = {
     name = ["OL8.5-x86_64-*"]
   }
 }
+
+block_device_mappings_ebs = [
+  {
+    device_name = "/dev/sda1" # root volume
+    volume_size = 30
+    volume_type = "gp3"
+  }
+]
 
 components_aws = []
 

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -2,7 +2,7 @@
 # BRANCH_NAME =
 # GH_ACTOR_NAME =
 
-configuration_version = "0.2.0"
+configuration_version = "0.2.1"
 description           = "shared rhel 6.10 base image"
 
 ami_base_name = "rhel_6_10"
@@ -21,6 +21,13 @@ parent_image = {
   include_deprecated = true
 }
 
+block_device_mappings_ebs = [
+  {
+    device_name = "/dev/sda1" # root volume
+    volume_size = 30
+    volume_type = "gp3"
+  }
+]
 
 # rhel6.10 cannot use amazon-ssm-agent, this is installed via user_data
 components_aws = [

--- a/commonimages/base/rhel_7_9/terraform.tfvars
+++ b/commonimages/base/rhel_7_9/terraform.tfvars
@@ -1,7 +1,7 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.0.9"
+configuration_version = "0.1.0"
 description           = "shared rhel 7.9 base image"
 
 ami_base_name = "rhel_7_9"
@@ -17,6 +17,14 @@ parent_image = {
     name = ["RHEL-7.9_HVM-*"]
   }
 }
+
+block_device_mappings_ebs = [
+  {
+    device_name = "/dev/sda1" # root volume
+    volume_size = 30
+    volume_type = "gp3"
+  }
+]
 
 components_aws = [
   "update-linux",

--- a/commonimages/base/rhel_8_5/terraform.tfvars
+++ b/commonimages/base/rhel_8_5/terraform.tfvars
@@ -1,7 +1,7 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.0.7"
+configuration_version = "0.0.8"
 description           = "shared rhel 8.5 base image"
 
 ami_base_name = "rhel_8_5"
@@ -17,6 +17,14 @@ parent_image = {
     name = ["RHEL-8.5_HVM-*x86*"]
   }
 }
+
+block_device_mappings_ebs = [
+  {
+    device_name = "/dev/sda1" # root volume
+    volume_size = 30
+    volume_type = "gp3"
+  }
+]
 
 components_aws = [
   "update-linux",

--- a/commonimages/base/shared.auto.tfvars
+++ b/commonimages/base/shared.auto.tfvars
@@ -1,14 +1,6 @@
 
 ami_name_prefix = "base"
 
-block_device_mappings_ebs = [
-  {
-    device_name = "/dev/sda1" # root volume
-    volume_size = 30
-    volume_type = "gp3"
-  }
-]
-
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 1 * ? *)"

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.0.3"
+configuration_version = "0.0.4"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 


### PR DESCRIPTION
unfortunately with ebs root volume sizes specified in shared.auto.tfvars at 30Gb this isn't enough to build a windows server 2012 r2 ami as the disk snapshot is > 30Gb

move the ebs value into each server config so it's specified in a per-instance basis