### PR TITLE
specify smallest instance type which will still support SQL Enterprise

### DIFF
--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -40,7 +40,7 @@ components_aws = [
 components_custom = []
 
 infrastructure_configuration = {
-  instance_types = ["t3.medium"]
+  instance_types = ["t3.xlarge"] # required for Windows SQL Server Enterprise minimum requirements
 }
 
 image_pipeline = {

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -40,7 +40,7 @@ components_aws = [
 components_custom = []
 
 infrastructure_configuration = {
-  instance_types = ["t3.xlarge"] # required for Windows SQL Server Enterprise minimum requirements
+  instance_types = ["t3.xlarge"] # Windows SQL Server Enterprise minimum requirements, 2012 R2 won't build unless these are met...
 }
 
 image_pipeline = {


### PR DESCRIPTION
seems that the build system requires a windows type that will support SQL Server Enterprise so this is the smallest reasonable (and least cost) type