### PR TITLE
use the AMI where EC2LaunchV2 is already included

### DIFF
--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.0.6"
+configuration_version = "0.0.7"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 
@@ -15,7 +15,7 @@ tags = {
 parent_image = {
   owner = "801119661308"
   ami_search_filters = {
-    name = ["Windows_Server-2012-R2_RTM-English-64Bit-Base-2023.08.10"] # specify as going EOL in 2023
+    name = ["EC2LaunchV2-Windows_Server-2012_R2_RTM-English-Full-Base-*"] # specify as going EOL in 2023
   }
 }
 
@@ -33,8 +33,8 @@ block_device_mappings_ebs = [
 ]
 
 components_aws = [
-  "amazon-cloudwatch-agent-windows",
-  "ec2launch-v2-windows"
+  "amazon-cloudwatch-agent-windows"
+  # "ec2launch-v2-windows" already baked into this ami
 ]
 
 components_custom = []


### PR DESCRIPTION
- AWS supply a Windows Server 2012 R2 ami with EC2LaunchV2 baked in
- use this rather since it's being kept up-to-date for us