### PR TITLE
Dso 2321/ami pipeline fix cron

### DIFF
--- a/commonimages/base/shared.auto.tfvars
+++ b/commonimages/base/shared.auto.tfvars
@@ -4,6 +4,7 @@ ami_name_prefix = "base"
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 1 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/commonimages/base/shared.auto.tfvars
+++ b/commonimages/base/shared.auto.tfvars
@@ -3,7 +3,7 @@ ami_name_prefix = "base"
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 1 * ? *)"
+    schedule_expression                = "cron(0 0 1 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.1.0"
+configuration_version = "0.1.1"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -46,7 +46,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 2 * ? *)"
+    schedule_expression                = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -47,6 +47,7 @@ infrastructure_configuration = {
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/commonimages/base/windows_2012_r2_SQL_2014/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2_SQL_2014/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2_SQL_2014_enterprise"
-configuration_version = "0.0.4"
+configuration_version = "0.0.5"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2 with SQL 2014 Enterprise"
 

--- a/commonimages/base/windows_2012_r2_SQL_2014/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2_SQL_2014/terraform.tfvars
@@ -45,6 +45,7 @@ infrastructure_configuration = {
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/commonimages/base/windows_2012_r2_SQL_2014/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2_SQL_2014/terraform.tfvars
@@ -44,7 +44,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 2 * ? *)"
+    schedule_expression                = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/teams/delius-core/oracle_db/terraform.tfvars
+++ b/teams/delius-core/oracle_db/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "delius_core_ol_8_5"
 ami_base_name         = "oracle_db_19c"
-configuration_version = "0.0.7"
+configuration_version = "0.0.8"
 release_or_patch      = "patch" # see nomis AMI image building strategy doc
 description           = "Delius Core Oracle Database Image"
 

--- a/teams/delius-core/oracle_db/terraform.tfvars
+++ b/teams/delius-core/oracle_db/terraform.tfvars
@@ -37,6 +37,7 @@ infrastructure_configuration = {
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/teams/delius-core/oracle_db/terraform.tfvars
+++ b/teams/delius-core/oracle_db/terraform.tfvars
@@ -36,7 +36,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 2 * ? *)"
+    schedule_expression                = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/teams/delius-iaps/iaps_server/terraform.tfvars
+++ b/teams/delius-iaps/iaps_server/terraform.tfvars
@@ -104,6 +104,7 @@ infrastructure_configuration = {
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/teams/delius-iaps/iaps_server/terraform.tfvars
+++ b/teams/delius-iaps/iaps_server/terraform.tfvars
@@ -103,7 +103,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 2 * ? *)"
+    schedule_expression                = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/teams/delius-iaps/iaps_server/terraform.tfvars
+++ b/teams/delius-iaps/iaps_server/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "delius"
 ami_base_name         = "iaps_server"
-configuration_version = "0.0.31"
+configuration_version = "0.0.32"
 
 release_or_patch = "patch" # see nomis AMI image building strategy doc
 description      = "Delius IAPS server"

--- a/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
+++ b/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "ol_8_5_oracledb_19c"
-configuration_version = "0.0.4"
+configuration_version = "0.0.5"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "hmpps oracle 19c image on oracle linux 8.5"
 

--- a/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
+++ b/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
@@ -91,6 +91,7 @@ infrastructure_configuration = {
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
+++ b/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
@@ -90,7 +90,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 2 * ? *)"
+    schedule_expression                = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/teams/hmpps/rhel_8_5/terraform.tfvars
+++ b/teams/hmpps/rhel_8_5/terraform.tfvars
@@ -46,6 +46,7 @@ infrastructure_configuration = {
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/teams/hmpps/rhel_8_5/terraform.tfvars
+++ b/teams/hmpps/rhel_8_5/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "rhel_8_5_join_to_azure"
-configuration_version = "0.0.1"
+configuration_version = "0.0.2"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "hmpps rhel 8.5 join to Azure domain"
 

--- a/teams/hmpps/rhel_8_5/terraform.tfvars
+++ b/teams/hmpps/rhel_8_5/terraform.tfvars
@@ -45,7 +45,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 2 * ? *)"
+    schedule_expression                = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -39,7 +39,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 2 * ? *)"
+    schedule_expression                = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
-configuration_version = "0.0.5"
+configuration_version = "0.0.6"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
-configuration_version = "0.0.6"
+configuration_version = "0.0.5"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 
@@ -39,7 +39,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression                = "cron(0 0 2 * ? *)"
+    schedule_expression = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -40,6 +40,7 @@ infrastructure_configuration = {
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/teams/nomis-data-hub/rhel_7_9_app/terraform.tfvars
+++ b/teams/nomis-data-hub/rhel_7_9_app/terraform.tfvars
@@ -37,6 +37,7 @@ infrastructure_configuration = {
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/teams/nomis-data-hub/rhel_7_9_app/terraform.tfvars
+++ b/teams/nomis-data-hub/rhel_7_9_app/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis_data_hub"
 ami_base_name         = "rhel_7_9_app"
-configuration_version = "0.0.1"
+configuration_version = "0.0.2"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis data hub rhel 7.9 app image"
 

--- a/teams/nomis-data-hub/rhel_7_9_app/terraform.tfvars
+++ b/teams/nomis-data-hub/rhel_7_9_app/terraform.tfvars
@@ -36,7 +36,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 2 * ? *)"
+    schedule_expression                = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/teams/nomis-data-hub/rhel_7_9_ems/terraform.tfvars
+++ b/teams/nomis-data-hub/rhel_7_9_ems/terraform.tfvars
@@ -37,6 +37,7 @@ infrastructure_configuration = {
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/teams/nomis-data-hub/rhel_7_9_ems/terraform.tfvars
+++ b/teams/nomis-data-hub/rhel_7_9_ems/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis_data_hub"
 ami_base_name         = "rhel_7_9_ems"
-configuration_version = "0.0.1"
+configuration_version = "0.0.2"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis data hub rhel 7.9 ems image"
 

--- a/teams/nomis-data-hub/rhel_7_9_ems/terraform.tfvars
+++ b/teams/nomis-data-hub/rhel_7_9_ems/terraform.tfvars
@@ -36,7 +36,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 2 * ? *)"
+    schedule_expression                = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
@@ -49,6 +49,7 @@ infrastructure_configuration = {
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
@@ -48,7 +48,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 2 * ? *)"
+    schedule_expression                = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "rhel_6_10_weblogic_appserver_10_3"
-configuration_version = "0.2.4"
+configuration_version = "0.2.5"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis rhel 6.10 weblogic appserver image"
 

--- a/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
@@ -93,6 +93,7 @@ infrastructure_configuration = {
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
@@ -92,7 +92,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 2 * ? *)"
+    schedule_expression                = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "rhel_7_9_oracledb_11_2"
-configuration_version = "0.4.5"
+configuration_version = "0.4.6"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis rhel 7.9 oracleDB 11.2 image"
 

--- a/teams/nomis/rhel_7_9_weblogic_xtag_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_weblogic_xtag_10_3/terraform.tfvars
@@ -49,6 +49,7 @@ infrastructure_configuration = {
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/teams/nomis/rhel_7_9_weblogic_xtag_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_weblogic_xtag_10_3/terraform.tfvars
@@ -48,7 +48,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 2 * ? *)"
+    schedule_expression                = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/teams/nomis/rhel_7_9_weblogic_xtag_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_weblogic_xtag_10_3/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "rhel_7_9_weblogic_xtag_10_3"
-configuration_version = "0.0.4"
+configuration_version = "0.0.5"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis rhel 7.9 weblogic XTAG image"
 

--- a/teams/oasys/bip/terraform.tfvars
+++ b/teams/oasys/bip/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "oasys"
 ami_base_name         = "bip"
-configuration_version = "0.0.1"
+configuration_version = "0.0.2"
 release_or_patch      = "release"
 description           = "oasys bip image"
 

--- a/teams/oasys/bip/terraform.tfvars
+++ b/teams/oasys/bip/terraform.tfvars
@@ -59,6 +59,7 @@ infrastructure_configuration = {
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/teams/oasys/bip/terraform.tfvars
+++ b/teams/oasys/bip/terraform.tfvars
@@ -58,7 +58,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 2 * ? *)"
+    schedule_expression                = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/teams/oasys/oracle_db/terraform.tfvars
+++ b/teams/oasys/oracle_db/terraform.tfvars
@@ -70,7 +70,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 2 * ? *)"
+    schedule_expression                = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/teams/oasys/oracle_db/terraform.tfvars
+++ b/teams/oasys/oracle_db/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "oasys"
 ami_base_name         = "oracle_db"
-configuration_version = "0.1.0"
+configuration_version = "0.1.1"
 release_or_patch      = "release"
 description           = "oasys oracle db image"
 

--- a/teams/oasys/oracle_db/terraform.tfvars
+++ b/teams/oasys/oracle_db/terraform.tfvars
@@ -71,6 +71,7 @@ infrastructure_configuration = {
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/teams/oasys/weblogic/terraform.tfvars
+++ b/teams/oasys/weblogic/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "oasys"
 ami_base_name         = "weblogic"
-configuration_version = "0.0.1"
+configuration_version = "0.0.2"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "oasys weblogic app server image"
 

--- a/teams/oasys/weblogic/terraform.tfvars
+++ b/teams/oasys/weblogic/terraform.tfvars
@@ -45,6 +45,7 @@ infrastructure_configuration = {
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/teams/oasys/weblogic/terraform.tfvars
+++ b/teams/oasys/weblogic/terraform.tfvars
@@ -44,7 +44,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 2 * ? *)"
+    schedule_expression                = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }

--- a/teams/oasys/webserver/terraform.tfvars
+++ b/teams/oasys/webserver/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "oasys"
 ami_base_name         = "webserver"
-configuration_version = "0.0.9"
+configuration_version = "0.0.10"
 release_or_patch      = "release"
 description           = "oasys webserver image"
 

--- a/teams/oasys/webserver/terraform.tfvars
+++ b/teams/oasys/webserver/terraform.tfvars
@@ -59,6 +59,7 @@ infrastructure_configuration = {
 image_pipeline = {
   schedule = {
     schedule_expression = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }
 

--- a/teams/oasys/webserver/terraform.tfvars
+++ b/teams/oasys/webserver/terraform.tfvars
@@ -58,7 +58,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression = "cron(0 0 2 * ? *)"
+    schedule_expression                = "cron(0 0 2 * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
   }
 }


### PR DESCRIPTION
When pipeline_execution_start_condition is explicitly set to EXPRESSION_MATCH_ONLY, it will build new images aligned with the defined cron schedule.
