### PR TITLE
Add pipeline_execution_start_condition to image builder module

### DIFF
--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.1.1"
+configuration_version = "0.1.2"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/commonimages/base/windows_2012_r2_SQL_2014/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2_SQL_2014/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2_SQL_2014_enterprise"
-configuration_version = "0.0.5"
+configuration_version = "0.0.6"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2 with SQL 2014 Enterprise"
 

--- a/modules/imagebuilder/main.tf
+++ b/modules/imagebuilder/main.tf
@@ -150,5 +150,6 @@ resource "aws_imagebuilder_image_pipeline" "this" {
   }
   schedule {
     schedule_expression = var.image_pipeline.schedule.schedule_expression
+    pipeline_execution_start_condition = var.image_pipeline.schedule.pipeline_execution_start_condition
   }
 }

--- a/modules/imagebuilder/main.tf
+++ b/modules/imagebuilder/main.tf
@@ -149,7 +149,7 @@ resource "aws_imagebuilder_image_pipeline" "this" {
     image_tests_enabled = false
   }
   schedule {
-    schedule_expression = var.image_pipeline.schedule.schedule_expression
+    schedule_expression                = var.image_pipeline.schedule.schedule_expression
     pipeline_execution_start_condition = var.image_pipeline.schedule.pipeline_execution_start_condition
   }
 }

--- a/modules/imagebuilder/variables.tf
+++ b/modules/imagebuilder/variables.tf
@@ -141,7 +141,7 @@ variable "systems_manager_agent" {
 variable "image_pipeline" {
   type = object({
     schedule = object({
-      schedule_expression = string
+      schedule_expression                = string
       pipeline_execution_start_condition = string
     })
   })

--- a/modules/imagebuilder/variables.tf
+++ b/modules/imagebuilder/variables.tf
@@ -142,6 +142,7 @@ variable "image_pipeline" {
   type = object({
     schedule = object({
       schedule_expression = string
+      pipeline_execution_start_condition = string
     })
   })
   description = "Pipeline configuration, see aws_imagebuilder_image_pipeline documentation for details on the parameters"

--- a/teams/delius-core/oracle_db/terraform.tfvars
+++ b/teams/delius-core/oracle_db/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "delius_core_ol_8_5"
 ami_base_name         = "oracle_db_19c"
-configuration_version = "0.0.8"
+configuration_version = "0.0.9"
 release_or_patch      = "patch" # see nomis AMI image building strategy doc
 description           = "Delius Core Oracle Database Image"
 

--- a/teams/delius-iaps/iaps_server/terraform.tfvars
+++ b/teams/delius-iaps/iaps_server/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "delius"
 ami_base_name         = "iaps_server"
-configuration_version = "0.0.32"
+configuration_version = "0.0.33"
 
 release_or_patch = "patch" # see nomis AMI image building strategy doc
 description      = "Delius IAPS server"

--- a/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
+++ b/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "ol_8_5_oracledb_19c"
-configuration_version = "0.0.5"
+configuration_version = "0.0.6"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "hmpps oracle 19c image on oracle linux 8.5"
 

--- a/teams/hmpps/rhel_8_5/terraform.tfvars
+++ b/teams/hmpps/rhel_8_5/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "rhel_8_5_join_to_azure"
-configuration_version = "0.0.2"
+configuration_version = "0.0.3"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "hmpps rhel 8.5 join to Azure domain"
 

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
-configuration_version = "0.0.6"
+configuration_version = "0.0.7"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 

--- a/teams/nomis-data-hub/rhel_7_9_app/terraform.tfvars
+++ b/teams/nomis-data-hub/rhel_7_9_app/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis_data_hub"
 ami_base_name         = "rhel_7_9_app"
-configuration_version = "0.0.2"
+configuration_version = "0.0.3"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis data hub rhel 7.9 app image"
 

--- a/teams/nomis-data-hub/rhel_7_9_ems/terraform.tfvars
+++ b/teams/nomis-data-hub/rhel_7_9_ems/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis_data_hub"
 ami_base_name         = "rhel_7_9_ems"
-configuration_version = "0.0.2"
+configuration_version = "0.0.3"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis data hub rhel 7.9 ems image"
 

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "rhel_6_10_weblogic_appserver_10_3"
-configuration_version = "0.2.5"
+configuration_version = "0.2.6"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis rhel 6.10 weblogic appserver image"
 

--- a/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "rhel_7_9_oracledb_11_2"
-configuration_version = "0.4.6"
+configuration_version = "0.4.7"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis rhel 7.9 oracleDB 11.2 image"
 

--- a/teams/nomis/rhel_7_9_weblogic_xtag_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_weblogic_xtag_10_3/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "rhel_7_9_weblogic_xtag_10_3"
-configuration_version = "0.0.5"
+configuration_version = "0.0.6"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis rhel 7.9 weblogic XTAG image"
 

--- a/teams/oasys/bip/terraform.tfvars
+++ b/teams/oasys/bip/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "oasys"
 ami_base_name         = "bip"
-configuration_version = "0.0.2"
+configuration_version = "0.0.3"
 release_or_patch      = "release"
 description           = "oasys bip image"
 

--- a/teams/oasys/oracle_db/terraform.tfvars
+++ b/teams/oasys/oracle_db/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "oasys"
 ami_base_name         = "oracle_db"
-configuration_version = "0.1.1"
+configuration_version = "0.1.2"
 release_or_patch      = "release"
 description           = "oasys oracle db image"
 

--- a/teams/oasys/weblogic/terraform.tfvars
+++ b/teams/oasys/weblogic/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "oasys"
 ami_base_name         = "weblogic"
-configuration_version = "0.0.2"
+configuration_version = "0.0.3"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "oasys weblogic app server image"
 

--- a/teams/oasys/webserver/terraform.tfvars
+++ b/teams/oasys/webserver/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "oasys"
 ami_base_name         = "webserver"
-configuration_version = "0.0.10"
+configuration_version = "0.0.11"
 release_or_patch      = "release"
 description           = "oasys webserver image"
 


### PR DESCRIPTION
- Added pipeline_execution_start_condition to the aws image builder module vars so it's recognised as changed
- Incremented configuration version number of cron-scheduled image builds