### PR TITLE
Fixed referencing for security groups

### DIFF
--- a/modernisation-platform/linux_pipeline_vars.tf
+++ b/modernisation-platform/linux_pipeline_vars.tf
@@ -25,7 +25,7 @@ locals {
       description        = "Description here"
       instance_types     = ["t3.medium"]
       name               = join("", [local.team_name, "_AmazonLinux2"])
-      security_group_ids = [data.terraform_remote_state.modernisation-platform-repo.outputs.image_builder_security_group_id]
+      security_group_ids = [data.terraform_remote_state.modernisation-platform-repo.outputs.image_builder_security_group_id.non_live_data]
       subnet_id          = data.terraform_remote_state.modernisation-platform-repo.outputs.non_live_private_subnet_ids[0]
       terminate_on_fail  = true
     }

--- a/modernisation-platform/rhel7_pipeline_vars.tf
+++ b/modernisation-platform/rhel7_pipeline_vars.tf
@@ -25,7 +25,7 @@ locals {
       description        = "Description here"
       instance_types     = ["t3.medium"]
       name               = join("", [local.team_name, "_rhel7"])
-      security_group_ids = [data.terraform_remote_state.modernisation-platform-repo.outputs.image_builder_security_group_id]
+      security_group_ids = [data.terraform_remote_state.modernisation-platform-repo.outputs.image_builder_security_group_id.non_live_data]
       subnet_id          = data.terraform_remote_state.modernisation-platform-repo.outputs.non_live_private_subnet_ids[0]
       terminate_on_fail  = true
     }

--- a/modernisation-platform/windows_2019_pipeline_vars.tf
+++ b/modernisation-platform/windows_2019_pipeline_vars.tf
@@ -25,7 +25,7 @@ locals {
       description        = "Description here"
       instance_types     = ["t3.medium"]
       name               = join("", [local.team_name, "_WindowsServer2019"])
-      security_group_ids = [data.terraform_remote_state.modernisation-platform-repo.outputs.image_builder_security_group_id]
+      security_group_ids = [data.terraform_remote_state.modernisation-platform-repo.outputs.image_builder_security_group_id.non_live_data]
       subnet_id          = data.terraform_remote_state.modernisation-platform-repo.outputs.non_live_private_subnet_ids[0]
       terminate_on_fail  = true
     }

--- a/modernisation-platform/windows_pipeline_vars.tf
+++ b/modernisation-platform/windows_pipeline_vars.tf
@@ -25,7 +25,7 @@ locals {
       description        = "Description here"
       instance_types     = ["t3.medium"]
       name               = join("", [local.team_name, "_WindowsServer2022"])
-      security_group_ids = [data.terraform_remote_state.modernisation-platform-repo.outputs.image_builder_security_group_id]
+      security_group_ids = [data.terraform_remote_state.modernisation-platform-repo.outputs.image_builder_security_group_id.non_live_data]
       subnet_id          = data.terraform_remote_state.modernisation-platform-repo.outputs.non_live_private_subnet_ids[0]
       terminate_on_fail  = true
     }


### PR DESCRIPTION
The `modernisation-platform` terraform fails due to a change in how outputs are created in the remote repository referenced by `data.terraform_remote_state.modernisation-platform-repo`.

This PR updates the references to correctly retrieve the strings from the remote statefile outputs.