### PR TITLE
Dso 2239/ansible failure handling in ami builds

### DIFF
--- a/commonimages/base/components/rhel_6_10/stig_rhel6_ansible.yml.tftpl
+++ b/commonimages/base/components/rhel_6_10/stig_rhel6_ansible.yml.tftpl
@@ -23,7 +23,6 @@ phases:
               set -e
               PATH=$PATH:/usr/local/bin
               run_ansible() {
-                set -e
                 repo="modernisation-platform-ami-builds"
                 ami_tag="${ami}"
 
@@ -88,5 +87,5 @@ phases:
                 rmdir $ansible_dir
               }
               echo "stig_rhel6_ansible $ami_tag start" | logger -p local3.info -t ami-component
-              run_ansible 2>&1 | logger -p local3.info -t ami-component -s 2>&1
+              run_ansible | logger -p local3.info -t ami-component -s 2>&1
               echo "stig_rhel6_ansible $ami_tag end" | logger -p local3.info -t ami-component

--- a/commonimages/base/components/rhel_6_10/stig_rhel6_ansible.yml.tftpl
+++ b/commonimages/base/components/rhel_6_10/stig_rhel6_ansible.yml.tftpl
@@ -23,6 +23,7 @@ phases:
               set -e
               PATH=$PATH:/usr/local/bin
               run_ansible() {
+                set -e
                 repo="modernisation-platform-ami-builds"
                 ami_tag="${ami}"
 

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -2,7 +2,7 @@
 # BRANCH_NAME =
 # GH_ACTOR_NAME =
 
-configuration_version = "0.2.2"
+configuration_version = "0.2.3"
 description           = "shared rhel 6.10 base image"
 
 ami_base_name = "rhel_6_10"
@@ -36,7 +36,7 @@ components_aws = [
 
 components_custom = [
   {
-    path       = "./components/rhel_6_10/stig_rhel6_ansible.yml.tftpl"
+    path       = "../../commonimages/base/components/rhel_6_10/stig_rhel6_ansible.yml.tftpl"
     parameters = []
   }
 ]

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -36,7 +36,7 @@ components_aws = [
 
 components_custom = [
   {
-    path       = "../../commonimages/base/components/rhel_6_10/stig_rhel6_ansible.yml.tftpl"
+    path       = "./components/rhel_6_10/stig_rhel6_ansible.yml.tftpl"
     parameters = []
   }
 ]

--- a/commonimages/components/templates/ansible.yml
+++ b/commonimages/components/templates/ansible.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.7
+      default: 0.0.8
       description: "Component version, increment if you make changes."
   - Platform:
       type: string

--- a/commonimages/components/templates/ansible.yml
+++ b/commonimages/components/templates/ansible.yml
@@ -47,7 +47,6 @@ phases:
               set -e
               PATH=$PATH:/usr/local/bin
               run_ansible() {
-                set -e
                 # define all params here to make standalone testing of script easier
                 repo="{{ AnsibleRepo }}"
                 ami_tag="{{ Ami }}"
@@ -124,5 +123,5 @@ phases:
                 rmdir $ansible_dir
               }
               echo "ansible $ami_tag start" | logger -p local3.info -t ami-component
-              run_ansible 2>&1 | logger -p local3.info -t ami-component -s 2>&1
+              run_ansible | logger -p local3.info -t ami-component -s 2>&1
               echo "ansible $ami_tag end" | logger -p local3.info -t ami-component

--- a/commonimages/components/templates/ansible.yml
+++ b/commonimages/components/templates/ansible.yml
@@ -47,6 +47,7 @@ phases:
               set -e
               PATH=$PATH:/usr/local/bin
               run_ansible() {
+                set -e
                 # define all params here to make standalone testing of script easier
                 repo="{{ AnsibleRepo }}"
                 ami_tag="{{ Ami }}"

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/locals.tf
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/locals.tf
@@ -3,7 +3,7 @@ locals {
   components_common = [
     {
       name    = "ansible"
-      version = "0.0.7"
+      version = "0.0.5"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/locals.tf
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/locals.tf
@@ -3,7 +3,7 @@ locals {
   components_common = [
     {
       name    = "ansible"
-      version = "0.0.5"
+      version = "0.0.7"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
@@ -36,6 +36,10 @@ components_aws = [
 ]
 
 components_custom = [
+  {
+    path       = "../../commonimages/base/components/rhel_6_10/stig_rhel6_ansible.yml.tftpl"
+    parameters = []
+  }
 ]
 
 systems_manager_agent = {

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "rhel_6_10_weblogic_appserver_10_3"
-configuration_version = "0.2.6"
+configuration_version = "0.2.7"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis rhel 6.10 weblogic appserver image"
 


### PR DESCRIPTION
- Ensure ansible component failure does not progress onto image build by removing 2>&1 on run_ansible function in .tftpl
- Update failing ansible component on nomis rhel_6_10_weblogic_appserver_10_3