### PR TITLE
Update AMIs to use latest ansible component version

### DIFF
--- a/commonimages/base/ol_8_5/locals.tf
+++ b/commonimages/base/ol_8_5/locals.tf
@@ -4,7 +4,7 @@ locals {
   components_common = [
     {
       name    = "ansible"
-      version = "0.0.6"
+      version = "0.0.11"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/commonimages/base/ol_8_5/terraform.tfvars
+++ b/commonimages/base/ol_8_5/terraform.tfvars
@@ -1,7 +1,7 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.0.6"
+configuration_version = "0.0.7"
 description           = "shared oracle linux 8.5 base image"
 
 ami_base_name = "ol_8_5"

--- a/commonimages/base/rhel_6_10/locals.tf
+++ b/commonimages/base/rhel_6_10/locals.tf
@@ -12,7 +12,7 @@ locals {
       parameters = []
       }, {
       name    = "ansible"
-      version = "0.0.5"
+      version = "0.0.11"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -2,7 +2,7 @@
 # BRANCH_NAME =
 # GH_ACTOR_NAME =
 
-configuration_version = "0.2.5"
+configuration_version = "0.2.6"
 description           = "shared rhel 6.10 base image"
 
 ami_base_name = "rhel_6_10"

--- a/commonimages/base/rhel_7_9/locals.tf
+++ b/commonimages/base/rhel_7_9/locals.tf
@@ -8,7 +8,7 @@ locals {
       parameters = []
       }, {
       name    = "ansible"
-      version = "0.0.5"
+      version = "0.0.11"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/commonimages/base/rhel_7_9/terraform.tfvars
+++ b/commonimages/base/rhel_7_9/terraform.tfvars
@@ -1,7 +1,7 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.1.0"
+configuration_version = "0.1.1"
 description           = "shared rhel 7.9 base image"
 
 ami_base_name = "rhel_7_9"

--- a/commonimages/base/rhel_8_5/locals.tf
+++ b/commonimages/base/rhel_8_5/locals.tf
@@ -4,7 +4,7 @@ locals {
   components_common = [
     {
       name    = "ansible"
-      version = "0.0.6"
+      version = "0.0.11"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/commonimages/base/rhel_8_5/terraform.tfvars
+++ b/commonimages/base/rhel_8_5/terraform.tfvars
@@ -1,7 +1,7 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.0.8"
+configuration_version = "0.0.9"
 description           = "shared rhel 8.5 base image"
 
 ami_base_name = "rhel_8_5"

--- a/teams/delius-core/oracle_db/locals.tf
+++ b/teams/delius-core/oracle_db/locals.tf
@@ -3,7 +3,7 @@ locals {
   components_common = [
     {
       name    = "ansible"
-      version = "0.0.6"
+      version = "0.0.11"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/teams/delius-core/oracle_db/terraform.tfvars
+++ b/teams/delius-core/oracle_db/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "delius_core_ol_8_5"
 ami_base_name         = "oracle_db_19c"
-configuration_version = "0.0.9"
+configuration_version = "0.0.10"
 release_or_patch      = "patch" # see nomis AMI image building strategy doc
 description           = "Delius Core Oracle Database Image"
 

--- a/teams/hmpps/ol_8_5_oracledb_19c/locals.tf
+++ b/teams/hmpps/ol_8_5_oracledb_19c/locals.tf
@@ -3,7 +3,7 @@ locals {
   components_common = [
     {
       name    = "ansible"
-      version = "0.0.5"
+      version = "0.0.11"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
+++ b/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "ol_8_5_oracledb_19c"
-configuration_version = "0.0.6"
+configuration_version = "0.0.7"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "hmpps oracle 19c image on oracle linux 8.5"
 

--- a/teams/hmpps/rhel_8_5/locals.tf
+++ b/teams/hmpps/rhel_8_5/locals.tf
@@ -3,7 +3,7 @@ locals {
   components_common = [
     {
       name    = "ansible"
-      version = "0.0.6"
+      version = "0.0.11"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/teams/hmpps/rhel_8_5/terraform.tfvars
+++ b/teams/hmpps/rhel_8_5/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "rhel_8_5_join_to_azure"
-configuration_version = "0.0.3"
+configuration_version = "0.0.4"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "hmpps rhel 8.5 join to Azure domain"
 

--- a/teams/nomis-data-hub/rhel_7_9_app/locals.tf
+++ b/teams/nomis-data-hub/rhel_7_9_app/locals.tf
@@ -3,7 +3,7 @@ locals {
   components_common = [
     {
       name    = "ansible"
-      version = "0.0.5"
+      version = "0.0.11"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/teams/nomis-data-hub/rhel_7_9_app/terraform.tfvars
+++ b/teams/nomis-data-hub/rhel_7_9_app/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis_data_hub"
 ami_base_name         = "rhel_7_9_app"
-configuration_version = "0.0.3"
+configuration_version = "0.0.4"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis data hub rhel 7.9 app image"
 

--- a/teams/nomis-data-hub/rhel_7_9_ems/locals.tf
+++ b/teams/nomis-data-hub/rhel_7_9_ems/locals.tf
@@ -3,7 +3,7 @@ locals {
   components_common = [
     {
       name    = "ansible"
-      version = "0.0.5"
+      version = "0.0.11"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/teams/nomis-data-hub/rhel_7_9_ems/terraform.tfvars
+++ b/teams/nomis-data-hub/rhel_7_9_ems/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis_data_hub"
 ami_base_name         = "rhel_7_9_ems"
-configuration_version = "0.0.3"
+configuration_version = "0.0.4"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis data hub rhel 7.9 ems image"
 

--- a/teams/nomis/rhel_7_9_oracledb_11_2/locals.tf
+++ b/teams/nomis/rhel_7_9_oracledb_11_2/locals.tf
@@ -3,7 +3,7 @@ locals {
   components_common = [
     {
       name    = "ansible"
-      version = "0.0.5"
+      version = "0.0.11"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "rhel_7_9_oracledb_11_2"
-configuration_version = "0.4.7"
+configuration_version = "0.4.8"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis rhel 7.9 oracleDB 11.2 image"
 

--- a/teams/nomis/rhel_7_9_weblogic_xtag_10_3/locals.tf
+++ b/teams/nomis/rhel_7_9_weblogic_xtag_10_3/locals.tf
@@ -3,7 +3,7 @@ locals {
   components_common = [
     {
       name    = "ansible"
-      version = "0.0.5"
+      version = "0.0.11"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/teams/nomis/rhel_7_9_weblogic_xtag_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_weblogic_xtag_10_3/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "rhel_7_9_weblogic_xtag_10_3"
-configuration_version = "0.0.6"
+configuration_version = "0.0.7"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis rhel 7.9 weblogic XTAG image"
 

--- a/teams/oasys/bip/locals.tf
+++ b/teams/oasys/bip/locals.tf
@@ -3,7 +3,7 @@ locals {
   components_common = [
     {
       name    = "ansible"
-      version = "0.0.6"
+      version = "0.0.11"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/teams/oasys/bip/terraform.tfvars
+++ b/teams/oasys/bip/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "oasys"
 ami_base_name         = "bip"
-configuration_version = "0.0.4"
+configuration_version = "0.0.5"
 release_or_patch      = "release"
 description           = "oasys bip image"
 

--- a/teams/oasys/oracle_db/locals.tf
+++ b/teams/oasys/oracle_db/locals.tf
@@ -3,7 +3,7 @@ locals {
   components_common = [
     {
       name    = "ansible"
-      version = "0.0.6"
+      version = "0.0.11"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/teams/oasys/oracle_db/terraform.tfvars
+++ b/teams/oasys/oracle_db/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "oasys"
 ami_base_name         = "oracle_db"
-configuration_version = "0.1.2"
+configuration_version = "0.1.3"
 release_or_patch      = "release"
 description           = "oasys oracle db image"
 

--- a/teams/oasys/weblogic/locals.tf
+++ b/teams/oasys/weblogic/locals.tf
@@ -3,7 +3,7 @@ locals {
   components_common = [
     {
       name    = "ansible"
-      version = "0.0.6"
+      version = "0.0.11"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/teams/oasys/weblogic/terraform.tfvars
+++ b/teams/oasys/weblogic/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "oasys"
 ami_base_name         = "weblogic"
-configuration_version = "0.0.3"
+configuration_version = "0.0.4"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "oasys weblogic app server image"
 

--- a/teams/oasys/webserver/locals.tf
+++ b/teams/oasys/webserver/locals.tf
@@ -3,7 +3,7 @@ locals {
   components_common = [
     {
       name    = "ansible"
-      version = "0.0.5"
+      version = "0.0.11"
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/teams/oasys/webserver/terraform.tfvars
+++ b/teams/oasys/webserver/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "oasys"
 ami_base_name         = "webserver"
-configuration_version = "0.0.11"
+configuration_version = "0.0.12"
 release_or_patch      = "release"
 description           = "oasys webserver image"
 


### PR DESCRIPTION
The latest ansible component version with pipefails enabled is 0.0.11. 
All AMIs need to use the latest version to ensure image build failures are captured properly.