### PR TITLE
DSOS-2467: copy XTAG AMI into nomis accounts for EC2 instance

### DIFF
--- a/teams/nomis/rhel_7_9_weblogic_xtag_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_weblogic_xtag_10_3/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "rhel_7_9_weblogic_xtag_10_3"
-configuration_version = "0.0.7"
+configuration_version = "0.0.8"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis rhel 7.9 weblogic XTAG image"
 
@@ -55,7 +55,23 @@ image_pipeline = {
 
 launch_template_exists = false
 
-account_to_distribute_ami = "core-shared-services-production"
+accounts_to_distribute_ami_by_branch = {
+  # push to main branch
+  main = [
+    "core-shared-services-production",
+    "nomis-development",
+    "nomis-test",
+    "nomis-preproduction",
+    "nomis-production",
+  ]
+
+  # push to any other branch / local run
+  default = [
+    "core-shared-services-production",
+    "nomis-development",
+    "nomis-test",
+  ]
+}
 
 launch_permission_accounts_by_branch = {
   # push to main branch


### PR DESCRIPTION
Moving XTAG from ASG to EC2 so AMI needs to be copied into account.