### PR TITLE
Dso/dsos 2550/fix server 2022 ami psreadline

### DIFF
--- a/commonimages/components/templates/powershell_core.yml
+++ b/commonimages/components/templates/powershell_core.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.3.0
+      default: 0.4.0
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -13,7 +13,7 @@ parameters:
       description: Platform.
   - PowerShellCoreVersion:
       type: string
-      default: 7.3.6
+      default: 7.4.1
       description: Version of the PowerShell Core to install
 phases:
   - name: build

--- a/commonimages/components/templates/psreadline_fix.yml
+++ b/commonimages/components/templates/psreadline_fix.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.1
+      default: 0.0.2
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -19,4 +19,4 @@ phases:
         inputs:
           commands:
             - |
-              Install-Module -Name PSReadLine -Repository PSGallery -MinimumVersion 2.2.2 -Force
+              Install-Module -Name PSReadLine -Repository PSGallery -MinimumVersion 2.2.2 -Force -AllowClobber -Confirm:$false

--- a/commonimages/components/templates/psreadline_fix.yml
+++ b/commonimages/components/templates/psreadline_fix.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.3
+      default: 0.0.4
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -25,17 +25,17 @@ phases:
 
               # delete old versions of Windows PowerShell PSReadline which are the issue
 
-              $moduleDirectories = Get-ChildItem -Path "C:\Program Files\WindowsPowerShell\Modules\PSReadline" -Directory -Depth 0
+              $psreadlineModuleDirectories = Get-ChildItem -Path "C:\Program Files\WindowsPowerShell\Modules\PSReadline" -Directory
 
               foreach ($psreadlineModuleDirectory in $psreadlineModuleDirectories) {
                 $moduleDirectoryPath = $psreadlineModuleDirectory.FullName
-                $moduleDirectoryName = $psresdlineModuleDirectory.Name
+                $moduleDirectoryName = $psreadlineModuleDirectory.Name
 
                 if ($moduleDirectoryName -le "2.2.2") {
                 Remove-Item -Recurse -Force -Path $moduleDirectoryPath
                 }
               }
 
-              $PSReadlineVersion = (Get-Module -ListAvailable PSReadLine).Version.ToString()
+              $PSReadlineVersion = (Get-Module -ListAvailable PSReadLine).Version
 
               Write-Host "PSReadline Module Version: $PSReadlineVersion"

--- a/commonimages/components/templates/psreadline_fix.yml
+++ b/commonimages/components/templates/psreadline_fix.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.2
+      default: 0.0.3
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -19,4 +19,23 @@ phases:
         inputs:
           commands:
             - |
+              Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+
               Install-Module -Name PSReadLine -Repository PSGallery -MinimumVersion 2.2.2 -Force -AllowClobber -Confirm:$false
+
+              # delete old versions of Windows PowerShell PSReadline which are the issue
+
+              $moduleDirectories = Get-ChildItem -Path "C:\Program Files\WindowsPowerShell\Modules\PSReadline" -Directory -Depth 0
+
+              foreach ($psreadlineModuleDirectory in $psreadlineModuleDirectories) {
+                $moduleDirectoryPath = $psreadlineModuleDirectory.FullName
+                $moduleDirectoryName = $psresdlineModuleDirectory.Name
+
+                if ($moduleDirectoryName -le "2.2.2") {
+                Remove-Item -Recurse -Force -Path $moduleDirectoryPath
+                }
+              }
+
+              $PSReadlineVersion = (Get-Module -ListAvailable PSReadLine).Version.ToString()
+
+              Write-Host "PSReadline Module Version: $PSReadlineVersion"

--- a/commonimages/components/templates/psreadline_fix.yml
+++ b/commonimages/components/templates/psreadline_fix.yml
@@ -1,0 +1,21 @@
+---
+name: psreadline_fix
+description: Component to fix PSReadline not rendering shell in things like Fleet Manager sessions on Windows Server 2022
+schemaVersion: 1.0
+parameters:
+  - Version:
+      type: string
+      default: 0.0.1
+      description: Component version (update this each time the file changes)
+  - Platform:
+      type: string
+      default: "Windows"
+      description: Platform.
+phases:
+  - name: build
+    steps:
+      - name: RunPSReadLineModuleInstallForceCommand
+        inputs:
+          commands: 
+            - |
+              Install-Module -Name PSReadLine -Repository PSGallery -MinimumVersion 2.2.2 -Force

--- a/commonimages/components/templates/psreadline_fix.yml
+++ b/commonimages/components/templates/psreadline_fix.yml
@@ -15,6 +15,7 @@ phases:
   - name: build
     steps:
       - name: RunPSReadLineModuleInstallForceCommand
+        action: ExecutePowerShell
         inputs:
           commands:
             - |

--- a/commonimages/components/templates/psreadline_fix.yml
+++ b/commonimages/components/templates/psreadline_fix.yml
@@ -16,6 +16,6 @@ phases:
     steps:
       - name: RunPSReadLineModuleInstallForceCommand
         inputs:
-          commands: 
+          commands:
             - |
               Install-Module -Name PSReadLine -Repository PSGallery -MinimumVersion 2.2.2 -Force

--- a/teams/hmpps/windows_server_2022/locals.tf
+++ b/teams/hmpps/windows_server_2022/locals.tf
@@ -12,7 +12,7 @@ locals {
     },
     {
       name       = "psreadline_fix"
-      version    = "0.0.1"
+      version    = "0.0.2"
       parameters = []
     }
   ]

--- a/teams/hmpps/windows_server_2022/locals.tf
+++ b/teams/hmpps/windows_server_2022/locals.tf
@@ -10,6 +10,11 @@ locals {
       version    = "0.0.2"
       parameters = []
     },
+    {
+      name       = "psreadline_fix"
+      version    = "0.0.1"
+      parameters = []
+    }
   ]
 
   component_template_args = {}

--- a/teams/hmpps/windows_server_2022/locals.tf
+++ b/teams/hmpps/windows_server_2022/locals.tf
@@ -12,7 +12,7 @@ locals {
     },
     {
       name       = "psreadline_fix"
-      version    = "0.0.2"
+      version    = "0.0.3"
       parameters = []
     }
   ]

--- a/teams/hmpps/windows_server_2022/locals.tf
+++ b/teams/hmpps/windows_server_2022/locals.tf
@@ -2,7 +2,7 @@ locals {
   components_common = [
     {
       name       = "powershell_core"
-      version    = "0.3.0"
+      version    = "0.4.0"
       parameters = []
     },
     {
@@ -12,7 +12,7 @@ locals {
     },
     {
       name       = "psreadline_fix"
-      version    = "0.0.3"
+      version    = "0.0.4"
       parameters = []
     }
   ]

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
-configuration_version = "0.1.0"
+configuration_version = "0.1.1"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -5,8 +5,8 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
-configuration_version = "0.0.9"
-release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
+configuration_version = "0.1.0"
+release_or_patch      = "patch" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 
 tags = {

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
-configuration_version = "0.1.3"
+configuration_version = "0.1.4"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
-configuration_version = "0.1.2"
+configuration_version = "0.1.3"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -6,7 +6,7 @@ region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
 configuration_version = "0.1.0"
-release_or_patch      = "patch" # or "patch", see nomis AMI image building strategy doc
+release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 
 tags = {

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
-configuration_version = "0.1.1"
+configuration_version = "0.1.2"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 


### PR DESCRIPTION
- add component to fix psreadline issue in server 2022
  - this issue results in not being able to type in Windows PowerShell windows using things like Fleet Manager
- upgrade Pwsh (core) component to latest 7.4.1
- tested with hmpp_windows_server_2022 ami builds