### PR TITLE
Dso/dsos 2568/fix windows 2012 components

### DIFF
--- a/commonimages/base/windows_2012_r2/locals.tf
+++ b/commonimages/base/windows_2012_r2/locals.tf
@@ -2,12 +2,12 @@ locals {
   components_common = [
     {
       name       = "chocolatey"
-      version    = "0.0.3"
+      version    = "0.0.4"
       parameters = []
     },
     {
-      name       = "powershell_core"
-      version    = "0.4.0"
+      name       = "powershell_core_server_2012"
+      version    = "0.0.1"
       parameters = []
     },
     {

--- a/commonimages/base/windows_2012_r2/locals.tf
+++ b/commonimages/base/windows_2012_r2/locals.tf
@@ -2,7 +2,7 @@ locals {
   components_common = [
     {
       name       = "chocolatey"
-      version    = "0.0.2"
+      version    = "0.0.3"
       parameters = []
     },
     {

--- a/commonimages/base/windows_2012_r2/locals.tf
+++ b/commonimages/base/windows_2012_r2/locals.tf
@@ -7,7 +7,7 @@ locals {
     },
     {
       name       = "powershell_core_server_2012"
-      version    = "0.0.1"
+      version    = "0.0.3"
       parameters = []
     },
     {

--- a/commonimages/base/windows_2012_r2/locals.tf
+++ b/commonimages/base/windows_2012_r2/locals.tf
@@ -1,13 +1,18 @@
 locals {
   components_common = [
     {
+      name       = "chocolatey"
+      version    = "0.0.1"
+      parameters = []
+    },
+    {
       name       = "powershell_core"
-      version    = "0.3.0"
+      version    = "0.4.0"
       parameters = []
     },
     {
       name       = "aws_cli"
-      version    = "0.0.3"
+      version    = "0.0.4"
       parameters = []
     },
   ]

--- a/commonimages/base/windows_2012_r2/locals.tf
+++ b/commonimages/base/windows_2012_r2/locals.tf
@@ -2,7 +2,7 @@ locals {
   components_common = [
     {
       name       = "chocolatey"
-      version    = "0.0.1"
+      version    = "0.0.2"
       parameters = []
     },
     {

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.1.4"
+configuration_version = "0.1.5"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.1.8"
+configuration_version = "0.1.9"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.1.3"
+configuration_version = "0.1.4"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.1.5"
+configuration_version = "0.1.6"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.1.6"
+configuration_version = "0.1.7"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.1.7"
+configuration_version = "0.1.8"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/commonimages/base/windows_2012_r2_SQL_2014/locals.tf
+++ b/commonimages/base/windows_2012_r2_SQL_2014/locals.tf
@@ -1,13 +1,18 @@
 locals {
   components_common = [
     {
-      name       = "powershell_core"
-      version    = "0.3.0"
+      name       = "chocolatey"
+      version    = "0.0.4"
+      parameters = []
+    },
+    {
+      name       = "powershell_core_server_2012"
+      version    = "0.0.3"
       parameters = []
     },
     {
       name       = "aws_cli"
-      version    = "0.0.3"
+      version    = "0.0.4"
       parameters = []
     },
   ]

--- a/commonimages/base/windows_2012_r2_SQL_2014/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2_SQL_2014/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2_SQL_2014_enterprise"
-configuration_version = "0.0.7"
+configuration_version = "0.0.8"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2 with SQL 2014 Enterprise"
 

--- a/commonimages/components/templates/aws_cli.yml
+++ b/commonimages/components/templates/aws_cli.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.3
+      default: 0.0.4
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -13,7 +13,7 @@ parameters:
       description: Platform.
   - AwsCliVersion:
       type: string
-      default: 2.13.14
+      default: 2.15.14
       description: Version of the AWS Cli v2 to install
 phases:
   - name: build

--- a/commonimages/components/templates/chocolatey.yml
+++ b/commonimages/components/templates/chocolatey.yml
@@ -1,0 +1,22 @@
+---
+name: chocolatey
+description: Component to install chocolatey
+schemaVersion: 1.0
+parameters:
+  - Version:
+      type: string
+      default: 0.0.1
+      description: Component version (update this each time the file changes)
+  - Platform:
+      type: string
+      default: "Windows"
+      description: Platform.
+phases:
+  - name: build
+    steps:
+      - name: InstallPowerShellCore
+        action: ExecutePowerShell
+        inputs:
+          commands:
+            - |
+              Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))

--- a/commonimages/components/templates/chocolatey.yml
+++ b/commonimages/components/templates/chocolatey.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.3
+      default: 0.0.4
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -14,7 +14,7 @@ parameters:
 phases:
   - name: build
     steps:
-      - name: InstallPowerShellCore
+      - name: InstallChocolatey
         action: ExecutePowerShell
         inputs:
           commands:
@@ -24,7 +24,9 @@ phases:
                 [System.Environment]::Exit(0)
               } else {
                 Write-Host "Installing Chocolatey"
-                Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+                Set-ExecutionPolicy Bypass -Scope Process -Force
+                [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+                Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
                 [System.Environment]::Exit(3010)
               }
 

--- a/commonimages/components/templates/chocolatey.yml
+++ b/commonimages/components/templates/chocolatey.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.2
+      default: 0.0.3
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -24,7 +24,7 @@ phases:
                 [System.Environment]::Exit(0)
               } else {
                 Write-Host "Installing Chocolatey"
-                Set-ExecutionPolicy Bypass -Scope Process -Force[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+                Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
                 [System.Environment]::Exit(3010)
               }
 

--- a/commonimages/components/templates/chocolatey.yml
+++ b/commonimages/components/templates/chocolatey.yml
@@ -29,4 +29,3 @@ phases:
                 Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
                 [System.Environment]::Exit(3010)
               }
-

--- a/commonimages/components/templates/chocolatey.yml
+++ b/commonimages/components/templates/chocolatey.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.1
+      default: 0.0.2
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -19,4 +19,12 @@ phases:
         inputs:
           commands:
             - |
-              Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+              if (Get-Command choco.exe -ErrorAction SilentlyContinue) {
+                Write-Host "Chocolatey already installed"
+                [System.Environment]::Exit(0)
+              } else {
+                Write-Host "Installing Chocolatey"
+                Set-ExecutionPolicy Bypass -Scope Process -Force[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+                [System.Environment]::Exit(3010)
+              }
+

--- a/commonimages/components/templates/powershell_core.yml
+++ b/commonimages/components/templates/powershell_core.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.6.0
+      default: 0.7.0
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -25,4 +25,4 @@ phases:
             - |
               choco install -y chocolatey-core.extension
               choco install -y kb3118401
-              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 REGISTER_MANIFEST=1 ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL=1 ENABLE_PSREMOTING=1 USE_MU=0 ENABLE_MU=0 DISABLE_TELEMETRY ADD_PATH=1"'
+              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 REGISTER_MANIFEST=1 ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL=1 ENABLE_PSREMOTING=1 USE_MU=0 ENABLE_MU=0 DISABLE_TELEMETRY ADD_PATH=1"' --packageparameters '"/CleanUpPath"'

--- a/commonimages/components/templates/powershell_core.yml
+++ b/commonimages/components/templates/powershell_core.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.7.0
+      default: 0.4.0
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -25,4 +25,4 @@ phases:
             - |
               choco install -y chocolatey-core.extension
               choco install -y kb3118401
-              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 REGISTER_MANIFEST=1 ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL=1 ENABLE_PSREMOTING=1 USE_MU=0 ENABLE_MU=0 DISABLE_TELEMETRY ADD_PATH=1"' --packageparameters '"/CleanUpPath"'
+              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 REGISTER_MANIFEST=1 ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL=1 ENABLE_PSREMOTING=1"'

--- a/commonimages/components/templates/powershell_core.yml
+++ b/commonimages/components/templates/powershell_core.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.5.0
+      default: 0.6.0
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -25,4 +25,4 @@ phases:
             - |
               choco install -y chocolatey-core.extension
               choco install -y kb3118401
-              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 REGISTER_MANIFEST=1 ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL=1 ENABLE_PSREMOTING=1 USE_MU=0 ENABLE_MU=0"'
+              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 REGISTER_MANIFEST=1 ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL=1 ENABLE_PSREMOTING=1 USE_MU=0 ENABLE_MU=0 DISABLE_TELEMETRY ADD_PATH=1"'

--- a/commonimages/components/templates/powershell_core_server_2012.yml
+++ b/commonimages/components/templates/powershell_core_server_2012.yml
@@ -1,11 +1,11 @@
 ---
-name: powershell_core
-description: Component to upgrade to using PowerShell Core
+name: powershell_core_server_2012
+description: Component to install PowerShell Core on Windows Server 2012, has different command line flags as there are not supported packages for this version since Windows Server 2012 r2 is nearing EOL
 schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.5.0
+      default: 0.0.1
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -25,4 +25,4 @@ phases:
             - |
               choco install -y chocolatey-core.extension
               choco install -y kb3118401
-              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 REGISTER_MANIFEST=1 ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL=1 ENABLE_PSREMOTING=1 USE_MU=0 ENABLE_MU=0"'
+              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1"'

--- a/commonimages/components/templates/powershell_core_server_2012.yml
+++ b/commonimages/components/templates/powershell_core_server_2012.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.1
+      default: 0.0.3
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -25,4 +25,4 @@ phases:
             - |
               choco install -y chocolatey-core.extension
               choco install -y kb3118401
-              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1"'
+              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 USE_MU=0 ENABLE_MU=0 ADD_PATH=1 DISABLE_TELEMETRY"'

--- a/teams/hmpps/windows_server_2022/locals.tf
+++ b/teams/hmpps/windows_server_2022/locals.tf
@@ -2,7 +2,7 @@ locals {
   components_common = [
     {
       name       = "powershell_core"
-      version    = "0.6.0"
+      version    = "0.7.0"
       parameters = []
     },
     {

--- a/teams/hmpps/windows_server_2022/locals.tf
+++ b/teams/hmpps/windows_server_2022/locals.tf
@@ -2,7 +2,7 @@ locals {
   components_common = [
     {
       name       = "powershell_core"
-      version    = "0.7.0"
+      version    = "0.4.0"
       parameters = []
     },
     {

--- a/teams/hmpps/windows_server_2022/locals.tf
+++ b/teams/hmpps/windows_server_2022/locals.tf
@@ -2,12 +2,12 @@ locals {
   components_common = [
     {
       name       = "powershell_core"
-      version    = "0.4.0"
+      version    = "0.6.0"
       parameters = []
     },
     {
       name       = "aws_cli"
-      version    = "0.0.2"
+      version    = "0.0.4"
       parameters = []
     },
     {

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
-configuration_version = "0.1.7"
+configuration_version = "0.1.8"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
-configuration_version = "0.1.5"
+configuration_version = "0.1.6"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
-configuration_version = "0.1.4"
+configuration_version = "0.1.5"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
-configuration_version = "0.1.6"
+configuration_version = "0.1.7"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 


### PR DESCRIPTION
Due to missing dependency (chocolatey) on the base windows_server_2012 ami subsequent components weren't installed
 
- added 'install chocolatey' component for windows_server_2012 base ami
  - created server 2012 specific 'install powershell core' step
  - aws cli now installs on server 2012
  
Also, while I was in here, updated the following components across the board

- Powershell Core component now installs LTS version 7.4.1 
- AWS Cli component now installs latest version 2.15.14

Note: powershell core component install flags differ between Windows server 2012 and other Windows Server versions as some install flags "do" have packages/support for server 2012 but not others and vice-versa. 

Tested by building ami's of both and making sure all builds complete/don't fail with errors or time outs.