### PR TITLE
Dso/add install git windows component

### DIFF
--- a/commonimages/base/windows_2012_r2/locals.tf
+++ b/commonimages/base/windows_2012_r2/locals.tf
@@ -15,6 +15,11 @@ locals {
       version    = "0.0.4"
       parameters = []
     },
+    {
+      name       = "git_windows"
+      version    = "0.0.1"
+      parameters = []
+    }
   ]
 
   component_template_args = {}

--- a/commonimages/base/windows_2012_r2/locals.tf
+++ b/commonimages/base/windows_2012_r2/locals.tf
@@ -7,7 +7,7 @@ locals {
     },
     {
       name       = "powershell_core_server_2012"
-      version    = "0.0.3"
+      version    = "0.0.4"
       parameters = []
     },
     {
@@ -17,7 +17,7 @@ locals {
     },
     {
       name       = "git_windows"
-      version    = "0.0.1"
+      version    = "0.0.2"
       parameters = []
     }
   ]

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.2.0"
+configuration_version = "0.2.1"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.1.9"
+configuration_version = "0.2.0"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/commonimages/base/windows_2012_r2_SQL_2014/locals.tf
+++ b/commonimages/base/windows_2012_r2_SQL_2014/locals.tf
@@ -15,6 +15,11 @@ locals {
       version    = "0.0.4"
       parameters = []
     },
+    {
+      name       = "git_windows"
+      version    = "0.0.1"
+      parameters = []
+    }
   ]
 
   component_template_args = {}

--- a/commonimages/base/windows_2012_r2_SQL_2014/locals.tf
+++ b/commonimages/base/windows_2012_r2_SQL_2014/locals.tf
@@ -7,7 +7,7 @@ locals {
     },
     {
       name       = "powershell_core_server_2012"
-      version    = "0.0.3"
+      version    = "0.0.4"
       parameters = []
     },
     {
@@ -17,7 +17,7 @@ locals {
     },
     {
       name       = "git_windows"
-      version    = "0.0.1"
+      version    = "0.0.2"
       parameters = []
     }
   ]

--- a/commonimages/base/windows_2012_r2_SQL_2014/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2_SQL_2014/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2_SQL_2014_enterprise"
-configuration_version = "0.0.9"
+configuration_version = "0.1.0"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2 with SQL 2014 Enterprise"
 

--- a/commonimages/base/windows_2012_r2_SQL_2014/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2_SQL_2014/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2_SQL_2014_enterprise"
-configuration_version = "0.0.8"
+configuration_version = "0.0.9"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2 with SQL 2014 Enterprise"
 

--- a/commonimages/components/templates/git_windows.yml
+++ b/commonimages/components/templates/git_windows.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.1
+      default: 0.0.2
       description: Component version (update this each time the file changes)
   - Platform:
       type: string

--- a/commonimages/components/templates/git_windows.yml
+++ b/commonimages/components/templates/git_windows.yml
@@ -1,0 +1,22 @@
+---
+name: git_windows
+description: Component to install Git for Windows
+schemaVersion: 1.0
+parameters:
+  - Version:
+      type: string
+      default: 0.0.1
+      description: Component version (update this each time the file changes)
+  - Platform:
+      type: string
+      default: "Windows"
+      description: Platform.
+phases:
+  - name: build
+    steps:
+      - name: InstallGitForWindows
+        action: ExecutePowerShell
+        inputs:
+          commands:
+            - |
+              choco install git.install -y

--- a/commonimages/components/templates/powershell_core_server_2012.yml
+++ b/commonimages/components/templates/powershell_core_server_2012.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.3
+      default: 0.4.0
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -25,4 +25,4 @@ phases:
             - |
               choco install -y chocolatey-core.extension
               choco install -y kb3118401
-              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 USE_MU=0 ENABLE_MU=0 ADD_PATH=1 DISABLE_TELEMETRY"'
+              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1"'

--- a/teams/hmpps/windows_server_2022/locals.tf
+++ b/teams/hmpps/windows_server_2022/locals.tf
@@ -17,7 +17,7 @@ locals {
     },
     {
       name       = "git_windows"
-      version    = "0.0.1"
+      version    = "0.0.2"
       parameters = []
     }
   ]

--- a/teams/hmpps/windows_server_2022/locals.tf
+++ b/teams/hmpps/windows_server_2022/locals.tf
@@ -14,6 +14,11 @@ locals {
       name       = "psreadline_fix"
       version    = "0.0.4"
       parameters = []
+    },
+    {
+      name       = "git_windows"
+      version    = "0.0.1"
+      parameters = []
     }
   ]
 

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
-configuration_version = "0.1.8"
+configuration_version = "0.1.9"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
-configuration_version = "0.1.9"
+configuration_version = "0.2.0"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 


### PR DESCRIPTION
- add windows git install component 
  - we're going to replace user-data scripts (mostly) by calling powershell modules from the `modernisation-platform-configuration-management` repo instead so need to run git commands on the Windows EC2 instances
- remove failing parameters from 'powershell-core-server-2012' component
  - these packages/flags aren't available for server 2012 r2 (just tidies up the log output in EC2 Image Builder)
- update the version(s) of everything so it'll all work
 
