### PR TITLE
stop referencing a version that doesn't exist

### DIFF
--- a/commonimages/base/windows_2012_r2/locals.tf
+++ b/commonimages/base/windows_2012_r2/locals.tf
@@ -7,7 +7,7 @@ locals {
     },
     {
       name       = "powershell_core_server_2012"
-      version    = "0.0.4"
+      version    = "0.5.0"
       parameters = []
     },
     {

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.2.1"
+configuration_version = "0.2.2"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/commonimages/base/windows_2012_r2_SQL_2014/locals.tf
+++ b/commonimages/base/windows_2012_r2_SQL_2014/locals.tf
@@ -7,7 +7,7 @@ locals {
     },
     {
       name       = "powershell_core_server_2012"
-      version    = "0.0.4"
+      version    = "0.5.0"
       parameters = []
     },
     {

--- a/commonimages/components/templates/powershell_core_server_2012.yml
+++ b/commonimages/components/templates/powershell_core_server_2012.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.4.0
+      default: 0.5.0
       description: Component version (update this each time the file changes)
   - Platform:
       type: string


### PR DESCRIPTION
- same issue with powershell-core-server-2012 component
- just build a version that can be incremented without getting the build-system confused