### PR TITLE
create server 2019 ami for use by ONR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -96,6 +96,10 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "terraform"
+    directory: "/teams/hmpps/windows_server_2019"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "terraform"
     directory: "/teams/nomis"
     schedule:
       interval: "daily"

--- a/teams/hmpps/windows_server_2019/locals.tf
+++ b/teams/hmpps/windows_server_2019/locals.tf
@@ -1,0 +1,26 @@
+locals {
+  components_common = [
+    {
+      name       = "powershell_core"
+      version    = "1.0.0"
+      parameters = []
+    },
+    {
+      name       = "aws_cli"
+      version    = "0.0.4"
+      parameters = []
+    },
+    {
+      name       = "psreadline_fix"
+      version    = "0.0.4"
+      parameters = []
+    },
+    {
+      name       = "git_windows"
+      version    = "0.0.2"
+      parameters = []
+    }
+  ]
+
+  component_template_args = {}
+}

--- a/teams/hmpps/windows_server_2019/terraform.tfvars
+++ b/teams/hmpps/windows_server_2019/terraform.tfvars
@@ -1,0 +1,132 @@
+# following are passed in via pipeline
+# BRANCH_NAME =
+# GH_ACTOR_NAME =
+
+region                = "eu-west-2"
+ami_name_prefix       = "hmpps"
+ami_base_name         = "windows_server_2019"
+configuration_version = "0.0.1"
+release_or_patch      = "patch" # or "patch", see nomis AMI image building strategy doc
+description           = "windows server 2019"
+
+tags = {
+  os-version = "windows server 2019"
+}
+
+parent_image = {
+  owner           = "core-shared-services-production"
+  arn_resource_id = "mp-windowsserver2019/x.x.x"
+}
+
+block_device_mappings_ebs = [
+  {
+    device_name = "/dev/sda1" # root volume
+    volume_size = 30
+    volume_type = "gp3"
+  }
+]
+
+components_aws = [
+  "amazon-cloudwatch-agent-windows",
+  "ec2launch-v2-windows"
+]
+
+components_custom = []
+
+infrastructure_configuration = {
+  instance_types = ["t3.medium"]
+}
+
+image_pipeline = {
+  schedule = {
+    schedule_expression                = "cron(0 0 2 * ? *)"
+    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
+  }
+}
+
+accounts_to_distribute_ami_by_branch = {
+  # push to main branch
+  main = [
+    "core-shared-services-production",
+    "hmpps-domain-services-development",
+    "hmpps-domain-services-test",
+    "hmpps-domain-services-preproduction",
+    "hmpps-domain-services-production",
+    # "corporate-staff-rostering-test",
+    # "corporate-staff-rostering-development",
+    # "corporate-staff-rostering-preproduction",
+    # "corporate-staff-rostering-production",
+    # "nomis-development",
+    # "nomis-test",
+    # "nomis-preproduction",
+    # "nomis-production",
+    # "oasys-development",
+    # "oasys-test",
+    # "oasys-preproduction",
+    # "oasys-production",
+    # "nomis-data-hub-development",
+    # "nomis-data-hub-test",
+    # "nomis-data-hub-preproduction",
+    # "nomis-data-hub-production"
+  ]
+
+  # push to any other branch / local run
+  default = [
+    "core-shared-services-production",
+    "hmpps-domain-services-development",
+    "hmpps-domain-services-test",
+    # "corporate-staff-rostering-development",
+    # "corporate-staff-rostering-test",
+    # "nomis-development",
+    # "nomis-test",
+    # "oasys-development",
+    # "oasys-test",
+    # "nomis-data-hub-development",
+    # "nomis-data-hub-test"
+  ]
+
+}
+
+launch_permission_accounts_by_branch = {
+  # push to main branch
+  main = [
+    "core-shared-services-production",
+    "hmpps-domain-services-development",
+    "hmpps-domain-services-test",
+    # "hmpps-domain-services-preproduction",
+    # "hmpps-domain-services-production",
+    # "corporate-staff-rostering-development",
+    # "corporate-staff-rostering-test",
+    # "corporate-staff-rostering-preproduction",
+    # "corporate-staff-rostering-production",
+    # "nomis-development",
+    # "nomis-test",
+    # "nomis-preproduction",
+    # "nomis-production",
+    # "oasys-development",
+    # "oasys-test",
+    # "oasys-preproduction",
+    # "oasys-production",
+    # "nomis-data-hub-development",
+    # "nomis-data-hub-test",
+    # "nomis-data-hub-preproduction",
+    # "nomis-data-hub-production"
+  ]
+
+  # push to any other branch / local run
+  default = [
+    "core-shared-services-production",
+    "hmpps-domain-services-development",
+    "hmpps-domain-services-test",
+    # "corporate-staff-rostering-development",
+    # "corporate-staff-rostering-test",
+    # "nomis-development",
+    # "nomis-test",
+    # "oasys-development",
+    # "oasys-test",
+    # "nomis-data-hub-development",
+    # "nomis-data-hub-test"
+  ]
+}
+
+launch_template_exists = false

--- a/teams/hmpps/windows_server_2019/terraform.tfvars
+++ b/teams/hmpps/windows_server_2019/terraform.tfvars
@@ -5,8 +5,8 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2019"
-configuration_version = "0.0.1"
-release_or_patch      = "patch" # or "patch", see nomis AMI image building strategy doc
+configuration_version = "0.0.2"
+release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2019"
 
 tags = {
@@ -48,41 +48,17 @@ accounts_to_distribute_ami_by_branch = {
   # push to main branch
   main = [
     "core-shared-services-production",
-    "hmpps-domain-services-development",
-    "hmpps-domain-services-test",
-    "hmpps-domain-services-preproduction",
-    "hmpps-domain-services-production",
-    # "corporate-staff-rostering-test",
-    # "corporate-staff-rostering-development",
-    # "corporate-staff-rostering-preproduction",
-    # "corporate-staff-rostering-production",
-    # "nomis-development",
-    # "nomis-test",
-    # "nomis-preproduction",
-    # "nomis-production",
-    # "oasys-development",
-    # "oasys-test",
-    # "oasys-preproduction",
-    # "oasys-production",
-    # "nomis-data-hub-development",
-    # "nomis-data-hub-test",
-    # "nomis-data-hub-preproduction",
-    # "nomis-data-hub-production"
+    "oasys-national-reporting-development",
+    "oasys-national-reporting-test",
+    "oasys-national-reporting-preproduction",
+    "oasys-national-reporting-production"
   ]
 
   # push to any other branch / local run
   default = [
     "core-shared-services-production",
-    "hmpps-domain-services-development",
-    "hmpps-domain-services-test",
-    # "corporate-staff-rostering-development",
-    # "corporate-staff-rostering-test",
-    # "nomis-development",
-    # "nomis-test",
-    # "oasys-development",
-    # "oasys-test",
-    # "nomis-data-hub-development",
-    # "nomis-data-hub-test"
+    "oasys-national-reporting-development",
+    "oasys-national-reporting-test"
   ]
 
 }
@@ -91,41 +67,17 @@ launch_permission_accounts_by_branch = {
   # push to main branch
   main = [
     "core-shared-services-production",
-    "hmpps-domain-services-development",
-    "hmpps-domain-services-test",
-    # "hmpps-domain-services-preproduction",
-    # "hmpps-domain-services-production",
-    # "corporate-staff-rostering-development",
-    # "corporate-staff-rostering-test",
-    # "corporate-staff-rostering-preproduction",
-    # "corporate-staff-rostering-production",
-    # "nomis-development",
-    # "nomis-test",
-    # "nomis-preproduction",
-    # "nomis-production",
-    # "oasys-development",
-    # "oasys-test",
-    # "oasys-preproduction",
-    # "oasys-production",
-    # "nomis-data-hub-development",
-    # "nomis-data-hub-test",
-    # "nomis-data-hub-preproduction",
-    # "nomis-data-hub-production"
+    "oasys-national-reporting-development",
+    "oasys-national-reporting-test",
+    "oasys-national-reporting-preproduction",
+    "oasys-national-reporting-production"
   ]
 
   # push to any other branch / local run
   default = [
     "core-shared-services-production",
-    "hmpps-domain-services-development",
-    "hmpps-domain-services-test",
-    # "corporate-staff-rostering-development",
-    # "corporate-staff-rostering-test",
-    # "nomis-development",
-    # "nomis-test",
-    # "oasys-development",
-    # "oasys-test",
-    # "nomis-data-hub-development",
-    # "nomis-data-hub-test"
+    "oasys-national-reporting-development",
+    "oasys-national-reporting-test"
   ]
 }
 

--- a/teams/hmpps/windows_server_2019/terragrunt.hcl
+++ b/teams/hmpps/windows_server_2019/terragrunt.hcl
@@ -1,0 +1,6 @@
+include {
+  path = find_in_parent_folders()
+}
+terraform {
+  source = "../../..//teams/nomis"
+}


### PR DESCRIPTION
- build shared windows server 2019 ami for ONR
- will only be shared into ONR spaces at this point
- uses windows components, git, pwsh_core, aws_cli and psreadline_fix