### PR TITLE
change to last known working ansible component for rhel 6

### DIFF
--- a/commonimages/base/rhel_6_10/locals.tf
+++ b/commonimages/base/rhel_6_10/locals.tf
@@ -12,7 +12,7 @@ locals {
       parameters = []
       }, {
       name    = "ansible"
-      version = "0.0.11"
+      version = "0.0.5" # set to last known working ansible component version
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -2,7 +2,7 @@
 # BRANCH_NAME =
 # GH_ACTOR_NAME =
 
-configuration_version = "0.2.7"
+configuration_version = "0.2.8"
 description           = "shared rhel 6.10 base image"
 
 ami_base_name = "rhel_6_10"

--- a/commonimages/base/rhel_8_5_arm64/README.md
+++ b/commonimages/base/rhel_8_5_arm64/README.md
@@ -1,0 +1,7 @@
+# Overview
+This directory holds represents definition and configuration required to build an Oracle Linux 8.5 base AMI.
+
+NOTE: Parent 8.5 AMI no longer exists so pipeline is broken
+FIXME: https://dsdmoj.atlassian.net/browse/DSOS-2558
+
+As of March 2024 the lowest Rhel 8 Linux version is 8.6


### PR DESCRIPTION
- newer 0.0.11 version of the ansible component fails
- revert to use last working version of this component (0.0.5) and see that this can build/be distributed
- have created a separate ticket to fix this component for rhel 6