### PR TITLE
fix issue with rhel 6 cryptography dependency from requirements.txt

### DIFF
--- a/ansible/constraints.rhel6.txt
+++ b/ansible/constraints.rhel6.txt
@@ -1,0 +1,1 @@
+cryptography==2.3

--- a/commonimages/base/components/rhel_6_10/stig_rhel6_ansible.yml.tftpl
+++ b/commonimages/base/components/rhel_6_10/stig_rhel6_ansible.yml.tftpl
@@ -47,7 +47,7 @@ phases:
                 # install python dependencies outside of virtual env so ansible
                 # can be executed remotely
                 cd $ansible_dir/$repo/ansible
-                $python -m pip install -r requirements.txt
+                $python -m pip install -r requirements.txt -c constraints.rhel6.txt
 
                 # activate virtual environment
                 mkdir $ansible_dir/python-venv && cd "$_"

--- a/commonimages/base/components/rhel_6_10/stig_rhel6_ansible.yml.tftpl
+++ b/commonimages/base/components/rhel_6_10/stig_rhel6_ansible.yml.tftpl
@@ -65,7 +65,7 @@ phases:
 
                 # install requirements in virtual env
                 cd $ansible_dir/$repo/ansible
-                $python -m pip install -r requirements.txt
+                $python -m pip install -r requirements.txt -c constraints.rhel6.txt
                 ansible-galaxy role install -r requirements.rhel6.yml
                 ansible-galaxy collection install -r requirements.rhel6.yml --force
 

--- a/commonimages/base/rhel_6_10/locals.tf
+++ b/commonimages/base/rhel_6_10/locals.tf
@@ -12,7 +12,7 @@ locals {
       parameters = []
       }, {
       name    = "ansible"
-      version = "0.0.12" # set to last known working ansible component version
+      version = "0.0.13" # set to last known working ansible component version
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/commonimages/base/rhel_6_10/locals.tf
+++ b/commonimages/base/rhel_6_10/locals.tf
@@ -12,7 +12,7 @@ locals {
       parameters = []
       }, {
       name    = "ansible"
-      version = "0.0.5" # set to last known working ansible component version
+      version = "0.0.12" # set to last known working ansible component version
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/commonimages/base/rhel_6_10/locals.tf
+++ b/commonimages/base/rhel_6_10/locals.tf
@@ -12,7 +12,7 @@ locals {
       parameters = []
       }, {
       name    = "ansible"
-      version = "0.0.13" # set to last known working ansible component version
+      version = "0.0.14" # set to last known working ansible component version
       parameters = [{
         name  = "Ami"
         value = join("_", [var.ami_name_prefix, var.ami_base_name])

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -2,7 +2,7 @@
 # BRANCH_NAME =
 # GH_ACTOR_NAME =
 
-configuration_version = "0.3.2"
+configuration_version = "0.3.3"
 description           = "shared rhel 6.10 base image"
 
 ami_base_name = "rhel_6_10"

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -2,7 +2,7 @@
 # BRANCH_NAME =
 # GH_ACTOR_NAME =
 
-configuration_version = "0.3.1"
+configuration_version = "0.3.2"
 description           = "shared rhel 6.10 base image"
 
 ami_base_name = "rhel_6_10"

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -2,7 +2,7 @@
 # BRANCH_NAME =
 # GH_ACTOR_NAME =
 
-configuration_version = "0.2.8"
+configuration_version = "0.2.9"
 description           = "shared rhel 6.10 base image"
 
 ami_base_name = "rhel_6_10"

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -2,7 +2,7 @@
 # BRANCH_NAME =
 # GH_ACTOR_NAME =
 
-configuration_version = "0.2.9"
+configuration_version = "0.3.0"
 description           = "shared rhel 6.10 base image"
 
 ami_base_name = "rhel_6_10"

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -2,7 +2,7 @@
 # BRANCH_NAME =
 # GH_ACTOR_NAME =
 
-configuration_version = "0.3.0"
+configuration_version = "0.3.1"
 description           = "shared rhel 6.10 base image"
 
 ami_base_name = "rhel_6_10"

--- a/commonimages/base/shared.auto.tfvars
+++ b/commonimages/base/shared.auto.tfvars
@@ -11,11 +11,7 @@ image_pipeline = {
 accounts_to_distribute_ami_by_branch = {
   # push to main branch
   main = [
-    "core-shared-services-production",
-    "oasys-national-reporting-development",
-    "oasys-national-reporting-preproduction",
-    "oasys-national-reporting-production",
-    "oasys-national-reporting-test"
+    "core-shared-services-production"
   ]
 
   default = [

--- a/commonimages/components/templates/ansible.yml
+++ b/commonimages/components/templates/ansible.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.12
+      default: 0.0.13
       description: "Component version, increment if you make changes."
   - Platform:
       type: string
@@ -83,7 +83,7 @@ phases:
                 # install python dependencies outside of virtual env so ansible
                 # can be executed remotely
                 cd $ansible_dir/$repo/$ansible_repo_dir
-                if [[ "$python" =~ 3.6]]; then
+                if [[ "$python" =~ 3.6 ]]; then
                   $python -m pip install -r requirements.txt -c constraints.rhel6.txt
                 else
                   $python -m pip install -r requirements.txt
@@ -105,7 +105,7 @@ phases:
 
                 # install requirements in virtual env
                 cd $ansible_dir/$repo/$ansible_repo_dir
-                if [[ "$python" =~ 3.6]]; then
+                if [[ "$python" =~ 3.6 ]]; then
                   $python -m pip install -r requirements.txt -c constraints.rhel6.txt
                 else
                   $python -m pip install -r requirements.txt

--- a/commonimages/components/templates/ansible.yml
+++ b/commonimages/components/templates/ansible.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.11
+      default: 0.0.12
       description: "Component version, increment if you make changes."
   - Platform:
       type: string
@@ -83,7 +83,11 @@ phases:
                 # install python dependencies outside of virtual env so ansible
                 # can be executed remotely
                 cd $ansible_dir/$repo/$ansible_repo_dir
-                $python -m pip install -r requirements.txt
+                if [[ "$python" =~ 3.6]]; then
+                  $python -m pip install -r requirements.txt -c constraints.rhel6.txt
+                else
+                  $python -m pip install -r requirements.txt
+                fi
 
                 # activate virtual environment
                 mkdir $ansible_dir/python-venv && cd "$_"
@@ -101,7 +105,11 @@ phases:
 
                 # install requirements in virtual env
                 cd $ansible_dir/$repo/$ansible_repo_dir
-                $python -m pip install -r requirements.txt
+                if [[ "$python" =~ 3.6]]; then
+                  $python -m pip install -r requirements.txt -c constraints.rhel6.txt
+                else
+                  $python -m pip install -r requirements.txt
+                fi
                 ansible-galaxy role install -r requirements.yml
                 ansible-galaxy collection install -r requirements.yml --force
 

--- a/commonimages/components/templates/ansible.yml
+++ b/commonimages/components/templates/ansible.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.13
+      default: 0.0.14
       description: "Component version, increment if you make changes."
   - Platform:
       type: string

--- a/commonimages/components/templates/ansible.yml
+++ b/commonimages/components/templates/ansible.yml
@@ -107,11 +107,13 @@ phases:
                 cd $ansible_dir/$repo/$ansible_repo_dir
                 if [[ "$python" =~ 3.6 ]]; then
                   $python -m pip install -r requirements.txt -c constraints.rhel6.txt
+                  ansible-galaxy role install -r requirements.rhel6.yml
+                  ansible-galaxy collection install -r requirements.rhel6.yml --force
                 else
                   $python -m pip install -r requirements.txt
+                  ansible-galaxy role install -r requirements.yml
+                  ansible-galaxy collection install -r requirements.yml --force
                 fi
-                ansible-galaxy role install -r requirements.yml
-                ansible-galaxy collection install -r requirements.yml --force
 
                 # run ansible (note comma after localhost is deliberate)
                 ansible-playbook site.yml \


### PR DESCRIPTION
- rhel 6 ami build has failed since Jan due to transitive dependency cryptography build requirements
  - this causes the build script to crash, tagging the build as 'failed'
- workaround is to supply a constraints.rhel6.txt file so that python requirements.txt doesn't use/allow > 2.3 version of cryptographic lib for Rhel 6 / Python 3.6 only
- has been tested successfully building the 3.2 (earlier) version of this ami without any errors/failures
- attempt to distribute the base ami to non-core-shared-services-production environments failed so have backed these changes out