### PR TITLE
extended distribution of oracle 19c image to onr env for testing

### DIFF
--- a/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
+++ b/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "ol_8_5_oracledb_19c"
-configuration_version = "0.0.7"
+configuration_version = "0.0.8"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "hmpps oracle 19c image on oracle linux 8.5"
 
@@ -115,6 +115,10 @@ accounts_to_distribute_ami_by_branch = {
     "nomis-combined-reporting-test",
     "nomis-combined-reporting-preproduction",
     "nomis-combined-reporting-production",
+    "oasys-national-reporting-development",
+    "oasys-national-reporting-test",
+    "oasys-national-reporting-preproduction",
+    "oasys-national-reporting-production",
   ]
 
   # push to any other branch / local run
@@ -128,6 +132,8 @@ accounts_to_distribute_ami_by_branch = {
     "corporate-staff-rostering-test",
     "nomis-combined-reporting-development",
     "nomis-combined-reporting-test",
+    "oasys-national-reporting-development",
+    "oasys-national-reporting-test",
   ]
 }
 
@@ -151,6 +157,10 @@ launch_permission_accounts_by_branch = {
     "nomis-combined-reporting-test",
     "nomis-combined-reporting-preproduction",
     "nomis-combined-reporting-production",
+    "oasys-national-reporting-development",
+    "oasys-national-reporting-test",
+    "oasys-national-reporting-preproduction",
+    "oasys-national-reporting-production",
   ]
 
   # push to any other branch / local run
@@ -164,6 +174,8 @@ launch_permission_accounts_by_branch = {
     "corporate-staff-rostering-test",
     "nomis-combined-reporting-development",
     "nomis-combined-reporting-test",
+    "oasys-national-reporting-development",
+    "oasys-national-reporting-test",
   ]
 }
 


### PR DESCRIPTION
- add oasys-national-reporting environments to distribution list for oracle 19c ami