### PR TITLE
add component to upgrade 2012 r2 base image to Powershell 5.1

### DIFF
--- a/commonimages/base/windows_2012_r2/locals.tf
+++ b/commonimages/base/windows_2012_r2/locals.tf
@@ -22,7 +22,7 @@ locals {
     },
     {
       name       = "powershell_5_1"
-      version    = "0.0.1"
+      version    = "0.0.2"
       parameters = []
     }
   ]

--- a/commonimages/base/windows_2012_r2/locals.tf
+++ b/commonimages/base/windows_2012_r2/locals.tf
@@ -19,6 +19,11 @@ locals {
       name       = "git_windows"
       version    = "0.0.2"
       parameters = []
+    },
+    {
+      name       = "powershell_5_1"
+      version    = "0.0.1"
+      parameters = []
     }
   ]
 

--- a/commonimages/base/windows_2012_r2/locals.tf
+++ b/commonimages/base/windows_2012_r2/locals.tf
@@ -22,7 +22,7 @@ locals {
     },
     {
       name       = "powershell_5_1"
-      version    = "0.0.4"
+      version    = "0.0.5"
       parameters = []
     }
   ]

--- a/commonimages/base/windows_2012_r2/locals.tf
+++ b/commonimages/base/windows_2012_r2/locals.tf
@@ -22,7 +22,7 @@ locals {
     },
     {
       name       = "powershell_5_1"
-      version    = "0.0.2"
+      version    = "0.0.3"
       parameters = []
     }
   ]

--- a/commonimages/base/windows_2012_r2/locals.tf
+++ b/commonimages/base/windows_2012_r2/locals.tf
@@ -22,7 +22,7 @@ locals {
     },
     {
       name       = "powershell_5_1"
-      version    = "0.0.3"
+      version    = "0.0.4"
       parameters = []
     }
   ]

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.2.6"
+configuration_version = "0.2.7"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.2.3"
+configuration_version = "0.2.4"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.2.4"
+configuration_version = "0.2.5"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.2.2"
+configuration_version = "0.2.3"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.2.5"
+configuration_version = "0.2.6"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/commonimages/components/templates/powershell_5_1.yml
+++ b/commonimages/components/templates/powershell_5_1.yml
@@ -1,0 +1,22 @@
+---
+name: powershell_5_1
+description: Component to install Windows Management Framework 5.1 on Windows Server 2012. This includes PowerShell 5.1 and will supercede Powershell 4.0 so we can use more modern commandlets.
+SchemaVersion: 1.0
+parameters:
+  - Version:
+      type: string
+      default: 0.0.1
+      description: Component version (update this each time the file changes)
+  - Platform:
+      type: string
+      default: "Windows"
+      description: Platform.
+phases:
+  - name: build
+    steps:
+      - name: InstallPowerShell_5_1
+        action: ExecutePowerShell
+        inputs:
+          commands:
+            - |
+              choco install -y powershell

--- a/commonimages/components/templates/powershell_5_1.yml
+++ b/commonimages/components/templates/powershell_5_1.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.2
+      default: 0.0.3
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -20,3 +20,4 @@ phases:
           commands:
             - |
               choco install -y powershell
+              exit 3010

--- a/commonimages/components/templates/powershell_5_1.yml
+++ b/commonimages/components/templates/powershell_5_1.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.3
+      default: 0.0.4
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -19,5 +19,11 @@ phases:
         inputs:
           commands:
             - |
-              choco install -y powershell
-              exit 3010
+              if ( $PSVersionTable.PSVersion.Major -ge 5 ) {
+                Write-Host "PowerShell 5 or higher is already installed"
+                exit 0
+              } else {
+                Write-Host "Installing PowerShell 5.1"
+                choco install -y powershell
+                exit 3010
+              }

--- a/commonimages/components/templates/powershell_5_1.yml
+++ b/commonimages/components/templates/powershell_5_1.yml
@@ -1,11 +1,11 @@
 ---
 name: powershell_5_1
 description: Component to install Windows Management Framework 5.1 on Windows Server 2012. This includes PowerShell 5.1 and will supercede Powershell 4.0 so we can use more modern commandlets.
-SchemaVersion: 1.0
+schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.1
+      default: 0.0.2
       description: Component version (update this each time the file changes)
   - Platform:
       type: string

--- a/commonimages/components/templates/powershell_5_1.yml
+++ b/commonimages/components/templates/powershell_5_1.yml
@@ -19,11 +19,12 @@ phases:
         inputs:
           commands:
             - |
-              if ( $PSVersionTable.PSVersion.Major -ge 5 ) {
-                Write-Host "PowerShell 5 or higher is already installed"
-                exit 0
-              } else {
+              $PSMajorVersion = $PSVersionTable.PSVersion.Major
+              if ( $PSMajorVersion -le 4 ) {
                 Write-Host "Installing PowerShell 5.1"
                 choco install -y powershell
                 exit 3010
+              } else {
+                Write-Host "PowerShell $PSMajorVersion is installed"
+                exit 0
               }

--- a/commonimages/components/templates/powershell_5_1.yml
+++ b/commonimages/components/templates/powershell_5_1.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.4
+      default: 0.0.5
       description: Component version (update this each time the file changes)
   - Platform:
       type: string


### PR DESCRIPTION
Existing base image ships with PowerShell 4.0 which is missing some very useful commandlets.

This PR adds a new component to ugrade the base image to use PowerShell 5.1 as the default.