### PR TITLE
Correct referencing to remote data outputs

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
-          terraform_version: 1.0.1
+          terraform_version: ~1.8
           terraform_wrapper: false
       - name: Terraform plan - example pipelines
         run: |

--- a/teams/example/linux_pipeline_vars.tf
+++ b/teams/example/linux_pipeline_vars.tf
@@ -25,7 +25,7 @@ locals {
       description        = "Description here"
       instance_types     = ["t2.nano", "t3.micro"]
       name               = join("", [local.team_name, "_AmazonLinux2"])
-      security_group_ids = [data.terraform_remote_state.modernisation-platform-repo.outputs.image_builder_security_group_id]
+      security_group_ids = [data.terraform_remote_state.modernisation-platform-repo.outputs.image_builder_security_group_id.non_live_data]
       subnet_id          = data.terraform_remote_state.modernisation-platform-repo.outputs.non_live_private_subnet_ids[0]
       terminate_on_fail  = true
     }

--- a/teams/example/windows_pipeline_vars.tf
+++ b/teams/example/windows_pipeline_vars.tf
@@ -25,7 +25,7 @@ locals {
       description        = "Description here"
       instance_types     = ["t2.nano", "t3.micro"]
       name               = join("", [local.team_name, "_WindowsServer2022"])
-      security_group_ids = [data.terraform_remote_state.modernisation-platform-repo.outputs.image_builder_security_group_id]
+      security_group_ids = [data.terraform_remote_state.modernisation-platform-repo.outputs.image_builder_security_group_id.non_live_data]
       subnet_id          = data.terraform_remote_state.modernisation-platform-repo.outputs.non_live_private_subnet_ids[0]
       terminate_on_fail  = true
     }

--- a/teams/example/windows_s3_test_pipeline_vars.tf
+++ b/teams/example/windows_s3_test_pipeline_vars.tf
@@ -31,7 +31,7 @@ locals {
       description        = "Description here"
       instance_types     = ["t3.medium"]
       name               = join("", [local.team_name, "_WindowsServer2022_s3_test"])
-      security_group_ids = [data.terraform_remote_state.modernisation-platform-repo.outputs.image_builder_security_group_id]
+      security_group_ids = [data.terraform_remote_state.modernisation-platform-repo.outputs.image_builder_security_group_id.non_live_data]
       subnet_id          = data.terraform_remote_state.modernisation-platform-repo.outputs.non_live_private_subnet_ids[0]
       terminate_on_fail  = true
     }


### PR DESCRIPTION
This PR does the following:
* Bumps the floor terraform version to `1.8` from a previous hard value of `1.0.1`
* Corrects the referencing in the remote state output to correctly retrieve a security group ID value

This should resolve https://github.com/ministryofjustice/modernisation-platform/issues/6860