### PR TITLE
DSOS-2871: stop automated nomis ami builds

### DIFF
--- a/modules/imagebuilder/main.tf
+++ b/modules/imagebuilder/main.tf
@@ -148,8 +148,11 @@ resource "aws_imagebuilder_image_pipeline" "this" {
   image_tests_configuration {
     image_tests_enabled = false
   }
-  schedule {
-    schedule_expression                = var.image_pipeline.schedule.schedule_expression
-    pipeline_execution_start_condition = var.image_pipeline.schedule.pipeline_execution_start_condition
+  dynamic "schedule" {
+    for_each = var.image_pipeline.schedule != null ? [var.image_pipeline.schedule] : []
+    content {
+      schedule_expression                = schedule.value.schedule_expression
+      pipeline_execution_start_condition = schedule.value.pipeline_execution_start_condition
+    }
   }
 }

--- a/modules/imagebuilder/variables.tf
+++ b/modules/imagebuilder/variables.tf
@@ -146,8 +146,10 @@ variable "image_pipeline" {
     })
   })
   description = "Pipeline configuration, see aws_imagebuilder_image_pipeline documentation for details on the parameters"
+  default = {
+    schedule = null
+  }
 }
-
 
 variable "launch_permission_account_names" {
   type        = list(string)

--- a/modules/imagebuilder/variables.tf
+++ b/modules/imagebuilder/variables.tf
@@ -140,10 +140,10 @@ variable "systems_manager_agent" {
 
 variable "image_pipeline" {
   type = object({
-    schedule = object({
+    schedule = optional(object({
       schedule_expression                = string
       pipeline_execution_start_condition = string
-    })
+    }))
   })
   description = "Pipeline configuration, see aws_imagebuilder_image_pipeline documentation for details on the parameters"
   default = {

--- a/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_6_10_weblogic_appserver_10_3/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "rhel_6_10_weblogic_appserver_10_3"
-configuration_version = "0.2.15"
+configuration_version = "0.2.16"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis rhel 6.10 weblogic appserver image"
 
@@ -51,10 +51,6 @@ infrastructure_configuration = {
 }
 
 image_pipeline = {
-  schedule = {
-    schedule_expression                = "cron(0 0 2 * ? *)"
-    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
-  }
 }
 
 launch_template_exists = false

--- a/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_oracledb_11_2/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "rhel_7_9_oracledb_11_2"
-configuration_version = "0.4.8"
+configuration_version = "0.4.9"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis rhel 7.9 oracleDB 11.2 image"
 
@@ -91,10 +91,6 @@ infrastructure_configuration = {
 }
 
 image_pipeline = {
-  schedule = {
-    schedule_expression                = "cron(0 0 2 * ? *)"
-    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
-  }
 }
 
 accounts_to_distribute_ami_by_branch = {

--- a/teams/nomis/rhel_7_9_weblogic_xtag_10_3/terraform.tfvars
+++ b/teams/nomis/rhel_7_9_weblogic_xtag_10_3/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "nomis"
 ami_base_name         = "rhel_7_9_weblogic_xtag_10_3"
-configuration_version = "0.0.8"
+configuration_version = "0.0.9"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "nomis rhel 7.9 weblogic XTAG image"
 
@@ -47,10 +47,6 @@ infrastructure_configuration = {
 }
 
 image_pipeline = {
-  schedule = {
-    schedule_expression                = "cron(0 0 2 * ? *)"
-    pipeline_execution_start_condition = "EXPRESSION_MATCH_ONLY"
-  }
 }
 
 launch_template_exists = false


### PR DESCRIPTION
Build on demand rather than via a monthly schedule to save costs. May re-enable these later if we sort out a process for deleting old AMIs.