### PR TITLE
Added missing directories to Dependabot file script

### DIFF
--- a/.github/workflows/generate-dependabot-file.yml
+++ b/.github/workflows/generate-dependabot-file.yml
@@ -11,6 +11,11 @@ on:
       - 'scripts/generate-dependabot-file.sh'
   workflow_dispatch:
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+  pull-requests: write # For posting comments to PR
+
 defaults:
   run:
     shell: bash

--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -23,10 +23,22 @@ echo "Writing dependabot.yml file"
 version: 2
 
 updates:
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: gomod
+    directory: /scripts/minimise-comments
+    schedule:
+      interval: daily
+
+  - package-ecosystem: pip
+    directory: /ansible
+    schedule:
+      interval: daily
+
   # Dependabot doesn't currently support wildcard or multiple directory declarations within
   # a dependabot configuration, so we need to add all directories individually
   # See: github.com/dependabot/dependabot-core/issues/2178


### PR DESCRIPTION
A scan of this repository with `StepSecurity` showed there are two directories with dependendencies that aren't being monitored at present. I also observed that no permissions are defined for the action which generates a dependabot action.

This PR updates the `generate-dependabot-file.sh` script and applies permissions in line with other jobs in the repository.