### PR TITLE
build at 12:00 and distribute

### DIFF
--- a/teams/delius-core/mis_windows_server/terraform.tfvars
+++ b/teams/delius-core/mis_windows_server/terraform.tfvars
@@ -79,7 +79,7 @@ infrastructure_configuration = {
 
 image_pipeline = {
   schedule = {
-    schedule_expression                = "cron(0 12 * * ? *)"
+    schedule_expression                = "cron(0 13 * * ? *)"
     pipeline_execution_start_condition = "EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE"
   }
 }


### PR DESCRIPTION
- remove non-existent environment from distribution list
- build at 13:00 local time today
- build regardless - see https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_Schedule.html 
 - version update to 0.0.3 to guarantee this (hopefully) 