### PR TITLE
Changes to remove nomis-combined-reporting-development, from everywhere

### DIFF
--- a/commonimages/base/ol_8_5/terraform.tfvars
+++ b/commonimages/base/ol_8_5/terraform.tfvars
@@ -1,7 +1,7 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.0.8"
+configuration_version = "0.0.9"
 description           = "shared oracle linux 8.5 base image"
 
 ami_base_name = "ol_8_5"

--- a/commonimages/base/rhel_6_10/terraform.tfvars
+++ b/commonimages/base/rhel_6_10/terraform.tfvars
@@ -2,7 +2,7 @@
 # BRANCH_NAME =
 # GH_ACTOR_NAME =
 
-configuration_version = "0.3.3"
+configuration_version = "0.3.4"
 description           = "shared rhel 6.10 base image"
 
 ami_base_name = "rhel_6_10"

--- a/commonimages/base/rhel_7_9/terraform.tfvars
+++ b/commonimages/base/rhel_7_9/terraform.tfvars
@@ -1,7 +1,7 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.1.2"
+configuration_version = "0.1.3"
 description           = "shared rhel 7.9 base image"
 
 ami_base_name = "rhel_7_9"

--- a/commonimages/base/rhel_8_5/terraform.tfvars
+++ b/commonimages/base/rhel_8_5/terraform.tfvars
@@ -1,8 +1,7 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.1.1
-"
+configuration_version = "0.1.2"
 description           = "shared rhel 8.5 base image"
 
 ami_base_name = "rhel_8_5"

--- a/commonimages/base/rhel_8_5/terraform.tfvars
+++ b/commonimages/base/rhel_8_5/terraform.tfvars
@@ -1,7 +1,7 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.1.0"
+configuration_version = "0.1.1"
 description           = "shared rhel 8.5 base image"
 
 ami_base_name = "rhel_8_5"

--- a/commonimages/base/rhel_8_5/terraform.tfvars
+++ b/commonimages/base/rhel_8_5/terraform.tfvars
@@ -1,7 +1,8 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.1.1"
+configuration_version = "0.1.1
+"
 description           = "shared rhel 8.5 base image"
 
 ami_base_name = "rhel_8_5"

--- a/commonimages/base/rhel_8_5_arm64/terraform.tfvars
+++ b/commonimages/base/rhel_8_5_arm64/terraform.tfvars
@@ -1,7 +1,7 @@
 # following are passed in via pipeline
 # BRANCH_NAME =  
 # GH_ACTOR_NAME = 
-configuration_version = "0.0.1"
+configuration_version = "0.0.2"
 description           = "shared rhel 8.5 base image arm64"
 
 ami_base_name = "rhel_8_5_arm64"

--- a/commonimages/base/shared.auto.tfvars
+++ b/commonimages/base/shared.auto.tfvars
@@ -20,6 +20,8 @@ accounts_to_distribute_ami_by_branch = {
 
 }
 
+# removed "nomis-combined-reporting-development", from the section below (TM-1355)
+
 launch_permission_accounts_by_branch = {
 
   main = [
@@ -36,7 +38,6 @@ launch_permission_accounts_by_branch = {
     "hmpps-domain-services-test",
     "hmpps-domain-services-preproduction",
     "hmpps-domain-services-production",
-    "nomis-combined-reporting-development",
     "nomis-combined-reporting-preproduction",
     "nomis-combined-reporting-production",
     "nomis-combined-reporting-test",

--- a/commonimages/base/windows_2012_r2/terraform.tfvars
+++ b/commonimages/base/windows_2012_r2/terraform.tfvars
@@ -4,7 +4,7 @@
 
 region                = "eu-west-2"
 ami_base_name         = "windows_server_2012_r2"
-configuration_version = "0.2.8"
+configuration_version = "0.2.9"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "Windows Server 2012 R2"
 

--- a/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
+++ b/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
@@ -97,6 +97,9 @@ image_pipeline = {
 
 accounts_to_distribute_ami_by_branch = {
   # push to main branch
+
+  # removed     "nomis-combined-reporting-development", from sections below (TM-1355)
+
   main = [
     "core-shared-services-production",
     "oasys-development",
@@ -111,7 +114,6 @@ accounts_to_distribute_ami_by_branch = {
     "corporate-staff-rostering-test",
     "corporate-staff-rostering-preproduction",
     "corporate-staff-rostering-production",
-    "nomis-combined-reporting-development",
     "nomis-combined-reporting-test",
     "nomis-combined-reporting-preproduction",
     "nomis-combined-reporting-production",
@@ -134,7 +136,6 @@ accounts_to_distribute_ami_by_branch = {
     "hmpps-oem-test",
     "corporate-staff-rostering-development",
     "corporate-staff-rostering-test",
-    "nomis-combined-reporting-development",
     "nomis-combined-reporting-test",
     "oasys-national-reporting-development",
     "oasys-national-reporting-test",
@@ -159,7 +160,6 @@ launch_permission_accounts_by_branch = {
     "corporate-staff-rostering-test",
     "corporate-staff-rostering-preproduction",
     "corporate-staff-rostering-production",
-    "nomis-combined-reporting-development",
     "nomis-combined-reporting-test",
     "nomis-combined-reporting-preproduction",
     "nomis-combined-reporting-production",
@@ -182,7 +182,6 @@ launch_permission_accounts_by_branch = {
     "hmpps-oem-test",
     "corporate-staff-rostering-development",
     "corporate-staff-rostering-test",
-    "nomis-combined-reporting-development",
     "nomis-combined-reporting-test",
     "oasys-national-reporting-development",
     "oasys-national-reporting-test",

--- a/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
+++ b/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "ol_8_5_oracledb_19c"
-configuration_version = "0.0.9"
+configuration_version = "0.0.10"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "hmpps oracle 19c image on oracle linux 8.5"
 

--- a/teams/hmpps/windows_server_2019/terraform.tfvars
+++ b/teams/hmpps/windows_server_2019/terraform.tfvars
@@ -46,6 +46,7 @@ image_pipeline = {
 
 accounts_to_distribute_ami_by_branch = {
   # push to main branch
+
   main = [
     "core-shared-services-production",
     "oasys-national-reporting-development",

--- a/teams/hmpps/windows_server_2019/terraform.tfvars
+++ b/teams/hmpps/windows_server_2019/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2019"
-configuration_version = "0.0.2"
+configuration_version = "0.0.3"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2019"
 


### PR DESCRIPTION
This is to physically remove the "nomis-combined-reporting-development", code from a number of places. It has been removed from the system so needs to come off the ami code as well.

Once run it should cause no issues when anything is generated on the systems. 