### PR TITLE
update template version, add version to other resources

### DIFF
--- a/commonimages/components/templates/aws_cli.yml
+++ b/commonimages/components/templates/aws_cli.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.0.4
+      default: 0.0.5
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -13,7 +13,7 @@ parameters:
       description: Platform.
   - AwsCliVersion:
       type: string
-      default: 2.15.14
+      default: 2.27.49
       description: Version of the AWS Cli v2 to install
 phases:
   - name: build

--- a/commonimages/components/templates/powershell_core.yml
+++ b/commonimages/components/templates/powershell_core.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 1.0.0
+      default: 1.1.0
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -13,7 +13,7 @@ parameters:
       description: Platform.
   - PowerShellCoreVersion:
       type: string
-      default: 7.4.1
+      default: 7.5.2
       description: Version of the PowerShell Core to install
 phases:
   - name: build
@@ -25,4 +25,4 @@ phases:
             - |
               choco install -y chocolatey-core.extension
               choco install -y kb3118401
-              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 REGISTER_MANIFEST=1 ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL=1 ENABLE_PSREMOTING=1"'
+              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 REGISTER_MANIFEST=1 ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL=1 ENABLE_PSREMOTING=1"' --force

--- a/commonimages/components/templates/powershell_core_server_2012.yml
+++ b/commonimages/components/templates/powershell_core_server_2012.yml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 parameters:
   - Version:
       type: string
-      default: 0.5.0
+      default: 0.6.0
       description: Component version (update this each time the file changes)
   - Platform:
       type: string
@@ -13,7 +13,7 @@ parameters:
       description: Platform.
   - PowerShellCoreVersion:
       type: string
-      default: 7.4.1
+      default: 7.5.2
       description: Version of the PowerShell Core to install
 phases:
   - name: build
@@ -25,4 +25,4 @@ phases:
             - |
               choco install -y chocolatey-core.extension
               choco install -y kb3118401
-              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1"'
+              choco install -y powershell-core --version '{{ PowerShellCoreVersion }}' --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1"' --force

--- a/modules/imagebuilder/main.tf
+++ b/modules/imagebuilder/main.tf
@@ -108,7 +108,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "this" {
 }
 
 resource "aws_imagebuilder_distribution_configuration" "this" {
-  name        = local.team_ami_base_name
+  name        = replace("${local.team_ami_base_name}_${var.configuration_version}", ".", "_")
   description = var.description
   tags        = local.tags
 
@@ -139,7 +139,7 @@ resource "aws_imagebuilder_distribution_configuration" "this" {
 }
 
 resource "aws_imagebuilder_image_pipeline" "this" {
-  name                             = local.team_ami_base_name
+  name                             = replace("${local.team_ami_base_name}_${var.configuration_version}", ".", "_")
   description                      = var.description
   image_recipe_arn                 = aws_imagebuilder_image_recipe.this.arn
   infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.this.arn

--- a/teams/delius-core/mis_windows_server/locals.tf
+++ b/teams/delius-core/mis_windows_server/locals.tf
@@ -1,5 +1,32 @@
 locals {
-  components_common = []
+  components_common = [
+    {
+      name       = "chocolatey"
+      version    = "0.0.5"
+      parameters = []
+    },
+
+    {
+      name       = "powershell_core"
+      version    = "1.1.0"
+      parameters = []
+    },
+    {
+      name       = "aws_cli"
+      version    = "0.0.5"
+      parameters = []
+    },
+    {
+      name       = "psreadline_fix"
+      version    = "0.0.4"
+      parameters = []
+    },
+    {
+      name       = "git_windows"
+      version    = "0.0.2"
+      parameters = []
+    }
+  ]
 
   component_template_args = {}
 }

--- a/teams/delius-core/mis_windows_server/terraform.tfvars
+++ b/teams/delius-core/mis_windows_server/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "delius"
 ami_base_name         = "mis_windows_server"
-configuration_version = "0.0.3"
+configuration_version = "0.0.4"
 
 release_or_patch = "patch" # see nomis AMI image building strategy doc
 description      = "Delius MIS server"

--- a/teams/delius-core/mis_windows_server/terraform.tfvars
+++ b/teams/delius-core/mis_windows_server/terraform.tfvars
@@ -50,26 +50,6 @@ components_custom = [
   {
     path       = "./components/mis_windows_server/delius_mis_configure_cloudwatch_agent.yml"
     parameters = []
-  },
-  {
-    path       = "../../commonimages/components/templates/psreadline_fix.yml"
-    parameters = []
-  },
-  {
-    path       = "../../commonimages/components/templates/powershell_core.yml"
-    parameters = []
-  },
-  {
-    path       = "../../commonimages/components/templates/git_windows.yml"
-    parameters = []
-  },
-  {
-    path       = "../../commonimages/components/templates/chocolatey.yml"
-    parameters = []
-  },
-  {
-    path       = "../../commonimages/components/templates/aws_cli.yml"
-    parameters = []
   }
 ]
 

--- a/teams/delius-core/mis_windows_server/versions.tf
+++ b/teams/delius-core/mis_windows_server/versions.tf
@@ -1,3 +1,3 @@
 terraform {
   required_version = "=1.5.7"
-} 
+}

--- a/teams/delius-core/mis_windows_server/versions.tf
+++ b/teams/delius-core/mis_windows_server/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "=1.5.7"
+} 

--- a/teams/delius-core/mis_windows_server/versions.tf
+++ b/teams/delius-core/mis_windows_server/versions.tf
@@ -1,3 +1,10 @@
 terraform {
+  backend "s3" {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
   required_version = "=1.5.7"
 }


### PR DESCRIPTION
# Update Components
- update aws cli component (latest aws cli version)
- update pwsh core version 
- update pwsh core version installer for 2012 r2

# Update delius-core windows server version
- error is because the 0.0.3 version was already run but failed

# Add version to other resources
- should stop 'resource is a dependency elsewhere issue' when trying to delete 0.0.1 of delius-mis image

```
│ Error: deleting Image Builder Infrastructure Configuration 
(arn:aws:imagebuilder:eu-west-2:374269020027:infrastructure-configuration/delius-mis-windows-server-0-0-1): 
operation error imagebuilder: DeleteInfrastructureConfiguration, https response error StatusCode: 400, 
RequestID: 73940eca-3bf4-4008-91ff-9d4f632801e9, ResourceDependencyException: Resource dependency error: 
The resource ARN 'arn:aws:imagebuilder:eu-west-2:374269020027:infrastructure-configuration/
delius-mis-windows-server-0-0-1' has other resources depended on it.
```