### PR TITLE
need to update template version now components exist

### DIFF
--- a/teams/delius-core/mis_windows_server/terraform.tfvars
+++ b/teams/delius-core/mis_windows_server/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "delius"
 ami_base_name         = "mis_windows_server"
-configuration_version = "0.0.4"
+configuration_version = "0.0.5"
 
 release_or_patch = "patch" # see nomis AMI image building strategy doc
 description      = "Delius MIS server"


### PR DESCRIPTION
- due to the way the template builder works you can't update the template version with "un-built" components
- change template version to 0.0.5 to re-do everything
- you have to do this because if you just re-run the failed build then you'll get a different error about "version already exists"