### PR TITLE
increase debug output

### DIFF
--- a/teams/delius-core/oracle_db/locals.tf
+++ b/teams/delius-core/oracle_db/locals.tf
@@ -13,6 +13,9 @@ locals {
         }, {
         name  = "AnsibleTags"
         value = "amibuild,oracle_19c_download"
+        }, {
+        name  = "AnsibleArgs"
+        value = "-vvv"
       }]
     }
   ]


### PR DESCRIPTION
- the delius-core db image stopped being built in March 2025
- add verbose logging to ansible component to see if we can make it more obvious what's failing