### PR TITLE
TM-1442 removing the oasys-national-reporting-development from the list

### DIFF
--- a/commonimages/base/shared.auto.tfvars
+++ b/commonimages/base/shared.auto.tfvars
@@ -51,7 +51,6 @@ launch_permission_accounts_by_branch = {
     "oasys-preproduction",
     "oasys-production",
     "oasys-test",
-    "oasys-national-reporting-development",
     "oasys-national-reporting-preproduction",
     "oasys-national-reporting-production",
     "oasys-national-reporting-test",

--- a/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
+++ b/teams/hmpps/ol_8_5_oracledb_19c/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "ol_8_5_oracledb_19c"
-configuration_version = "0.0.9"
+configuration_version = "0.0.10"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "hmpps oracle 19c image on oracle linux 8.5"
 
@@ -114,7 +114,6 @@ accounts_to_distribute_ami_by_branch = {
     "nomis-combined-reporting-test",
     "nomis-combined-reporting-preproduction",
     "nomis-combined-reporting-production",
-    "oasys-national-reporting-development",
     "oasys-national-reporting-test",
     "oasys-national-reporting-preproduction",
     "oasys-national-reporting-production",
@@ -134,7 +133,6 @@ accounts_to_distribute_ami_by_branch = {
     "corporate-staff-rostering-development",
     "corporate-staff-rostering-test",
     "nomis-combined-reporting-test",
-    "oasys-national-reporting-development",
     "oasys-national-reporting-test",
     "nomis-development",
     "nomis-test",
@@ -160,7 +158,6 @@ launch_permission_accounts_by_branch = {
     "nomis-combined-reporting-test",
     "nomis-combined-reporting-preproduction",
     "nomis-combined-reporting-production",
-    "oasys-national-reporting-development",
     "oasys-national-reporting-test",
     "oasys-national-reporting-preproduction",
     "oasys-national-reporting-production",
@@ -180,7 +177,6 @@ launch_permission_accounts_by_branch = {
     "corporate-staff-rostering-development",
     "corporate-staff-rostering-test",
     "nomis-combined-reporting-test",
-    "oasys-national-reporting-development",
     "oasys-national-reporting-test",
     "nomis-development",
     "nomis-test",

--- a/teams/hmpps/windows_server_2019/terraform.tfvars
+++ b/teams/hmpps/windows_server_2019/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2019"
-configuration_version = "0.0.2"
+configuration_version = "0.0.3"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2019"
 
@@ -48,7 +48,6 @@ accounts_to_distribute_ami_by_branch = {
   # push to main branch
   main = [
     "core-shared-services-production",
-    "oasys-national-reporting-development",
     "oasys-national-reporting-test",
     "oasys-national-reporting-preproduction",
     "oasys-national-reporting-production",
@@ -60,7 +59,6 @@ accounts_to_distribute_ami_by_branch = {
   # push to any other branch / local run
   default = [
     "core-shared-services-production",
-    "oasys-national-reporting-development",
     "oasys-national-reporting-test",
     "nomis-combined-reporting-test"
   ]
@@ -71,7 +69,6 @@ launch_permission_accounts_by_branch = {
   # push to main branch
   main = [
     "core-shared-services-production",
-    "oasys-national-reporting-development",
     "oasys-national-reporting-test",
     "oasys-national-reporting-preproduction",
     "oasys-national-reporting-production",
@@ -83,7 +80,6 @@ launch_permission_accounts_by_branch = {
   # push to any other branch / local run
   default = [
     "core-shared-services-production",
-    "oasys-national-reporting-development",
     "oasys-national-reporting-test",
     "nomis-combined-reporting-test"
   ]

--- a/teams/hmpps/windows_server_2022/terraform.tfvars
+++ b/teams/hmpps/windows_server_2022/terraform.tfvars
@@ -5,7 +5,7 @@
 region                = "eu-west-2"
 ami_name_prefix       = "hmpps"
 ami_base_name         = "windows_server_2022"
-configuration_version = "0.2.2"
+configuration_version = "0.2.3"
 release_or_patch      = "release" # or "patch", see nomis AMI image building strategy doc
 description           = "windows server 2022"
 
@@ -64,7 +64,6 @@ accounts_to_distribute_ami_by_branch = {
     "oasys-test",
     "oasys-preproduction",
     "oasys-production",
-    "oasys-national-reporting-development",
     "oasys-national-reporting-test",
     "oasys-national-reporting-preproduction",
     "oasys-national-reporting-production",
@@ -88,7 +87,6 @@ accounts_to_distribute_ami_by_branch = {
     "nomis-test",
     "oasys-development",
     "oasys-test",
-    "oasys-national-reporting-development",
     "oasys-national-reporting-test",
     "nomis-combined-reporting-test",
     "nomis-data-hub-development",
@@ -117,7 +115,6 @@ launch_permission_accounts_by_branch = {
     "oasys-test",
     "oasys-preproduction",
     "oasys-production",
-    "oasys-national-reporting-development",
     "oasys-national-reporting-test",
     "oasys-national-reporting-preproduction",
     "oasys-national-reporting-production",
@@ -141,7 +138,6 @@ launch_permission_accounts_by_branch = {
     "nomis-test",
     "oasys-development",
     "oasys-test",
-    "oasys-national-reporting-development",
     "oasys-national-reporting-test",
     "nomis-combined-reporting-test",
     "nomis-data-hub-development",


### PR DESCRIPTION
This PR is to remove all the versions of oasys-national-reporting-development from the system.

All the code, other than base, the configuration_version has been amended to add one to the current value.

Once approved the PR will be moved in.