### PR TITLE
Update references to `format-code` action

### DIFF
--- a/teams/delius-core/format.sh
+++ b/teams/delius-core/format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Formats code in the same way as the code-formatter GitHub action
-# See https://github.com/ministryofjustice/github-actions/blob/main/code-formatter/action.yml
+# See https://github.com/ministryofjustice/modernisation-platform-github-actions/tree/main/format-code
 # Use this to avoid code-formatter commits during a PR
 
 for binary in terraform npx; do

--- a/teams/delius-iaps/format.sh
+++ b/teams/delius-iaps/format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Formats code in the same way as the code-formatter GitHub action
-# See https://github.com/ministryofjustice/github-actions/blob/main/code-formatter/action.yml
+# See https://github.com/ministryofjustice/modernisation-platform-github-actions/tree/main/format-code
 # Use this to avoid code-formatter commits during a PR
 
 for binary in terraform npx; do

--- a/teams/nomis/format.sh
+++ b/teams/nomis/format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Formats code in the same way as the code-formatter GitHub action
-# See https://github.com/ministryofjustice/github-actions/blob/main/code-formatter/action.yml
+# See https://github.com/ministryofjustice/modernisation-platform-github-actions/tree/main/format-code
 # Use this to avoid code-formatter commits during a PR
 
 for binary in terraform npx; do

--- a/teams/oasys/format.sh
+++ b/teams/oasys/format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Formats code in the same way as the code-formatter GitHub action
-# See https://github.com/ministryofjustice/github-actions/blob/main/code-formatter/action.yml
+# See https://github.com/ministryofjustice/modernisation-platform-github-actions/tree/main/format-code
 # Use this to avoid code-formatter commits during a PR
 
 for binary in terraform npx; do


### PR DESCRIPTION
as per titles this PR updates some references to the `format-code` workflow now that its been migrated to the modernisation-platform-github-actions repo. 