### PR TITLE
Add dependabot cooldown

### DIFF
--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -4,6 +4,20 @@ set -euo pipefail
 
 dependabot_file=.github/dependabot.yml
 
+# Dependabot cooldown configuration (applies to version updates only)
+# Docs: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
+dependabot_cooldown_default_days="${DEPENDABOT_COOLDOWN_DEFAULT_DAYS:-7}"
+
+if ! [[ "$dependabot_cooldown_default_days" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: DEPENDABOT_COOLDOWN_DEFAULT_DAYS must be an integer (days), got: '$dependabot_cooldown_default_days'" >&2
+  exit 1
+fi
+
+if (( dependabot_cooldown_default_days < 1 || dependabot_cooldown_default_days > 90 )); then
+  echo "ERROR: DEPENDABOT_COOLDOWN_DEFAULT_DAYS must be between 1 and 90 (inclusive), got: '$dependabot_cooldown_default_days'" >&2
+  exit 1
+fi
+
 # Clear the dependabot file
 > $dependabot_file
 


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/12036

## How does this PR fix the problem?

Adds Dependabot cooldown configuration so newly released dependency versions must now wait 7 days by default before 
Dependabot raises a version-update PR (does not affect security updates).